### PR TITLE
Add option to display color filters as swatches

### DIFF
--- a/app/components/checkbox.tsx
+++ b/app/components/checkbox.tsx
@@ -1,34 +1,27 @@
+import { Check } from "@phosphor-icons/react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import * as React from "react";
 import { cn } from "~/lib/cn";
-import { IconCheck } from "./icons";
 
 interface CheckboxProps
   extends React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> {
-  label?: string;
+  label?: React.ReactNode;
 }
 
-const Checkbox = React.forwardRef<
+export let Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   CheckboxProps
 >(({ className, label, ...props }, ref) => (
-  <div className={cn("flex items-center space-x-2.5", className)}>
+  <div className={cn("flex items-center gap-2.5", className)}>
     <CheckboxPrimitive.Root
       ref={ref}
-      className={cn(
-        "peer w-5 h-5 shrink-0 border ring-offset-background focus-visible:outline-none focus-visible:ring focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-background data-[state=checked]:text-body",
-      )}
+      className="w-5 h-5 shrink-0 border border-line focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
       {...props}
     >
-      <CheckboxPrimitive.Indicator
-        className={cn("flex items-center justify-center text-current")}
-      >
-        <IconCheck className="h-3 w-3" />
+      <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+        <Check weight="bold" className="h-3 w-3" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
-    {label ? <span>{label}</span> : null}
+    {label ? typeof label === "string" ? <span>{label}</span> : label : null}
   </div>
 ));
-Checkbox.displayName = CheckboxPrimitive.Root.displayName;
-
-export { Checkbox };

--- a/app/components/tooltip.tsx
+++ b/app/components/tooltip.tsx
@@ -24,19 +24,25 @@ export let TooltipTrigger = ({
 }: TooltipTriggerProps) => <Trigger asChild={asChild} {...rest} />;
 
 export let TooltipContent = forwardRef<HTMLDivElement, TooltipContentProps>(
-  ({ children, className, sideOffset = 4, ...rest }, ref) => {
+  ({ children, className, sideOffset = 4, style, ...rest }, ref) => {
     return (
       <Content
         ref={ref}
         className={cn(
           "animate-slide-down-and-fade",
-          "z-50 px-4 rounded py-1 shadow-sm text-background bg-body opacity-0",
+          "z-50 px-4 rounded py-1 shadow-sm text-background bg-body",
           className,
         )}
         align="center"
         side="top"
         sideOffset={sideOffset}
         collisionPadding={8}
+        style={
+          {
+            "--slide-down-and-fade-duration": "0.3s",
+            ...style,
+          } as React.CSSProperties
+        }
         {...rest}
       >
         <Arrow asChild>

--- a/app/modules/product-form/options.tsx
+++ b/app/modules/product-form/options.tsx
@@ -6,38 +6,41 @@ import type { ProductVariantFragmentFragment } from "storefrontapi.generated";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/tooltip";
 import { cn } from "~/lib/cn";
 
-let variants = cva("border border-line hover:border-body cursor-pointer", {
-  variants: {
-    colorSize: {
-      sm: "w-8 h-8",
-      md: "w-10 h-10",
-      lg: "w-12 h-12",
-    },
-    buttonSize: {
-      sm: "min-w-8 h-8",
-      md: "min-w-10 h-10",
-      lg: "min-w-12 h-12",
-    },
-    imageSize: {
-      sm: "w-12 h-auto",
-      md: "w-16 h-auto",
-      lg: "w-20 h-auto",
-    },
-    shape: {
-      square: "",
-      circle: "rounded-full",
-      round: "rounded-md",
-    },
-    selected: {
-      true: "border-body",
-      false: "",
-    },
-    disabled: {
-      true: "diagonal",
-      false: "",
+export let variants = cva(
+  "border border-line hover:border-body cursor-pointer",
+  {
+    variants: {
+      colorSize: {
+        sm: "w-8 h-8",
+        md: "w-10 h-10",
+        lg: "w-12 h-12",
+      },
+      buttonSize: {
+        sm: "min-w-8 h-8",
+        md: "min-w-10 h-10",
+        lg: "min-w-12 h-12",
+      },
+      imageSize: {
+        sm: "w-12 h-auto",
+        md: "w-16 h-auto",
+        lg: "w-20 h-auto",
+      },
+      shape: {
+        square: "",
+        circle: "rounded-full",
+        round: "rounded-md",
+      },
+      selected: {
+        true: "border-body",
+        false: "",
+      },
+      disabled: {
+        true: "diagonal",
+        false: "",
+      },
     },
   },
-});
+);
 
 interface VariantOptionProps {
   selectedOptionValue: string;

--- a/app/sections/collection-filters/filters.tsx
+++ b/app/sections/collection-filters/filters.tsx
@@ -119,28 +119,37 @@ function ListItemFilter({
   let navigate = useNavigate();
   let [params] = useSearchParams();
   let location = useLocation();
+
   let filter = appliedFilters.find(
     (filter) => JSON.stringify(filter.filter) === option.input,
   );
+
   let [checked, setChecked] = useState(!!filter);
 
-  let handleCheckedChange = (checked: boolean) => {
+  function handleCheckedChange(checked: boolean) {
     setChecked(checked);
     if (checked) {
-      const link = getFilterLink(option.input as string, params, location);
+      let link = getFilterLink(option.input as string, params, location);
       navigate(link);
     } else if (filter) {
       let link = getAppliedFilterLink(filter, params, location);
       navigate(link);
     }
-  };
+  }
   return (
     <div className="flex gap-2">
       <Checkbox
         checked={checked}
         onCheckedChange={handleCheckedChange}
         label={
-          showFiltersCount ? `${option.label} (${option.count})` : option.label
+          showFiltersCount ? (
+            <span>
+              {option.label}{" "}
+              <span className="text-gray-700">({option.count})</span>
+            </span>
+          ) : (
+            option.label
+          )
         }
       />
     </div>

--- a/app/sections/collection-filters/filters.tsx
+++ b/app/sections/collection-filters/filters.tsx
@@ -22,11 +22,21 @@ import { getAppliedFilterLink, getFilterLink } from "~/lib/filter";
 import type { CollectionFiltersData } from ".";
 import { Input } from "../../modules/input";
 import { cn } from "~/lib/cn";
+import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/tooltip";
+import { type SwatchesConfigs, useThemeSettings } from "@weaverse/hydrogen";
+import { variants as productOptionsVariants } from "~/modules/product-form/options";
+
+const COLORS_FILTERS = ["Color", "Colors", "Colour", "Colours"];
 
 export function Filters({ className }: { className?: string }) {
   let parentInstance = useClosestWeaverseItem(".filters-list");
   let parentData = parentInstance.data as unknown as CollectionFiltersData;
-  let { expandFilters, showFiltersCount } = parentData;
+  let {
+    expandFilters,
+    showFiltersCount,
+    enableColorSwatch,
+    displayAsButtonFor,
+  } = parentData;
   let [params] = useSearchParams();
   let { collection, appliedFilters } = useLoaderData<
     CollectionDetailsQuery & {
@@ -36,33 +46,6 @@ export function Filters({ className }: { className?: string }) {
   >();
   let filters = collection.products.filters as Filter[];
 
-  let filterMarkup = (filter: Filter, option: Filter["values"][0]) => {
-    switch (filter.type) {
-      case "PRICE_RANGE": {
-        let priceFilter = params.get(`${FILTER_URL_PREFIX}price`);
-        let price = priceFilter
-          ? (JSON.parse(priceFilter) as ProductFilter["price"])
-          : undefined;
-        let min = Number.isNaN(Number(price?.min))
-          ? undefined
-          : Number(price?.min);
-        let max = Number.isNaN(Number(price?.max))
-          ? undefined
-          : Number(price?.max);
-        return <PriceRangeFilter min={min} max={max} />;
-      }
-
-      default:
-        return (
-          <ListItemFilter
-            appliedFilters={appliedFilters as AppliedFilter[]}
-            option={option}
-            showFiltersCount={showFiltersCount}
-          />
-        );
-    }
-  };
-
   return (
     <Accordion.Root
       type="multiple"
@@ -70,48 +53,87 @@ export function Filters({ className }: { className?: string }) {
       key={expandFilters.toString() + showFiltersCount}
       defaultValue={expandFilters ? filters.map((filter) => filter.id) : []}
     >
-      {filters.map((filter: Filter) => (
-        <Accordion.Item
-          key={filter.id}
-          value={filter.id}
-          className="w-full pb-6 pt-7"
-        >
-          <Accordion.Trigger className="flex w-full justify-between items-center [&>svg]:data-[state=open]:rotate-90">
-            <span>{filter.label}</span>
-            <IconCaretRight className="w-4 h-4 transition-transform rotate-0" />
-          </Accordion.Trigger>
-          <Accordion.Content
-            style={
-              {
-                "--slide-up-from": "var(--radix-accordion-content-height)",
-                "--slide-down-to": "var(--radix-accordion-content-height)",
-                "--slide-up-duration": "0.15s",
-                "--slide-down-duration": "0.15s",
-              } as React.CSSProperties
-            }
-            className={clsx([
-              "overflow-hidden",
-              "data-[state=closed]:animate-slide-up",
-              "data-[state=open]:animate-slide-down",
-            ])}
+      {filters.map((filter: Filter) => {
+        let asColorSwatch =
+          enableColorSwatch && COLORS_FILTERS.includes(filter.label);
+
+        return (
+          <Accordion.Item
+            key={filter.id}
+            value={filter.id}
+            className="w-full pb-6 pt-7"
           >
-            <ul key={filter.id} className="space-y-5 pt-8">
-              {filter.values?.map((option) => {
-                return <li key={option.id}>{filterMarkup(filter, option)}</li>;
-              })}
-            </ul>
-          </Accordion.Content>
-        </Accordion.Item>
-      ))}
+            <Accordion.Trigger className="flex w-full justify-between items-center [&>svg]:data-[state=open]:rotate-90">
+              <span>{filter.label}</span>
+              <IconCaretRight className="w-4 h-4 transition-transform rotate-0" />
+            </Accordion.Trigger>
+            <Accordion.Content
+              style={
+                {
+                  "--slide-up-from": "var(--radix-accordion-content-height)",
+                  "--slide-down-to": "var(--radix-accordion-content-height)",
+                  "--slide-up-duration": "0.15s",
+                  "--slide-down-duration": "0.15s",
+                } as React.CSSProperties
+              }
+              className={clsx([
+                "overflow-hidden",
+                "data-[state=closed]:animate-slide-up",
+                "data-[state=open]:animate-slide-down",
+              ])}
+            >
+              <div
+                key={filter.id}
+                className={clsx(
+                  "flex pt-8",
+                  asColorSwatch ? "gap-1.5 flex-wrap" : "flex-col gap-5",
+                )}
+              >
+                {filter.values?.map((option) => {
+                  switch (filter.type) {
+                    case "PRICE_RANGE": {
+                      let priceFilter = params.get(`${FILTER_URL_PREFIX}price`);
+                      let price = priceFilter
+                        ? (JSON.parse(priceFilter) as ProductFilter["price"])
+                        : undefined;
+                      let min = Number.isNaN(Number(price?.min))
+                        ? undefined
+                        : Number(price?.min);
+                      let max = Number.isNaN(Number(price?.max))
+                        ? undefined
+                        : Number(price?.max);
+                      return (
+                        <PriceRangeFilter key={option.id} min={min} max={max} />
+                      );
+                    }
+                    default:
+                      return (
+                        <ListItemFilter
+                          key={option.id}
+                          asColorSwatch={asColorSwatch}
+                          appliedFilters={appliedFilters as AppliedFilter[]}
+                          option={option}
+                          showFiltersCount={showFiltersCount}
+                        />
+                      );
+                  }
+                })}
+              </div>
+            </Accordion.Content>
+          </Accordion.Item>
+        );
+      })}
     </Accordion.Root>
   );
 }
 
 function ListItemFilter({
+  asColorSwatch,
   option,
   appliedFilters,
   showFiltersCount,
 }: {
+  asColorSwatch?: boolean;
   option: Filter["values"][0];
   appliedFilters: AppliedFilter[];
   showFiltersCount: boolean;
@@ -119,6 +141,8 @@ function ListItemFilter({
   let navigate = useNavigate();
   let [params] = useSearchParams();
   let location = useLocation();
+  let themeSettings = useThemeSettings();
+  let { options, swatches }: SwatchesConfigs = themeSettings.productSwatches;
 
   let filter = appliedFilters.find(
     (filter) => JSON.stringify(filter.filter) === option.input,
@@ -130,29 +154,75 @@ function ListItemFilter({
     setChecked(checked);
     if (checked) {
       let link = getFilterLink(option.input as string, params, location);
-      navigate(link);
+      navigate(link, { preventScrollReset: true });
     } else if (filter) {
       let link = getAppliedFilterLink(filter, params, location);
-      navigate(link);
+      navigate(link, { preventScrollReset: true });
     }
   }
-  return (
-    <div className="flex gap-2">
-      <Checkbox
-        checked={checked}
-        onCheckedChange={handleCheckedChange}
-        label={
-          showFiltersCount ? (
+
+  if (asColorSwatch) {
+    let swatchColor = swatches.colors.find(({ name }) => name === option.label);
+    let optionConf = options.find(({ name }) => {
+      return name.toLowerCase() === option.label.toLowerCase();
+    });
+
+    let { shape = "square", size = "md" } = optionConf || {};
+    return (
+      <Tooltip>
+        <TooltipTrigger>
+          <button
+            type="button"
+            className={cn(
+              productOptionsVariants({
+                colorSize: size,
+                shape,
+              }),
+              checked ? "p-1 border-line" : "border-line-subtle",
+            )}
+            onClick={() => handleCheckedChange(!checked)}
+          >
+            <span
+              className={cn(
+                "w-full h-full inline-block border-none hover:border-none",
+                productOptionsVariants({ shape }),
+              )}
+              style={{
+                backgroundColor:
+                  swatchColor?.value || option.label.toLowerCase(),
+              }}
+            />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {showFiltersCount ? (
             <span>
               {option.label}{" "}
-              <span className="text-gray-700">({option.count})</span>
+              <span className="text-gray-100">({option.count})</span>
             </span>
           ) : (
             option.label
-          )
-        }
-      />
-    </div>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Checkbox
+      checked={checked}
+      onCheckedChange={handleCheckedChange}
+      label={
+        showFiltersCount ? (
+          <span>
+            {option.label}{" "}
+            <span className="text-gray-700">({option.count})</span>
+          </span>
+        ) : (
+          option.label
+        )
+      }
+    />
   );
 }
 

--- a/app/sections/collection-filters/index.tsx
+++ b/app/sections/collection-filters/index.tsx
@@ -15,6 +15,8 @@ export interface CollectionFiltersData {
   filtersPosition: "sidebar" | "drawer";
   expandFilters: boolean;
   showFiltersCount: boolean;
+  enableColorSwatch: boolean;
+  displayAsButtonFor: string;
   productsPerRowDesktop: number;
   productsPerRowMobile: number;
   loadPrevText: string;
@@ -32,6 +34,8 @@ let CollectionFilters = forwardRef<HTMLElement, CollectionFiltersProps>(
       filtersPosition,
       expandFilters,
       showProductsCount,
+      enableColorSwatch,
+      displayAsButtonFor,
       productsPerRowDesktop,
       productsPerRowMobile,
       loadPrevText,
@@ -180,6 +184,7 @@ export let schema: HydrogenComponentSchema = {
           label: "Display as button for:",
           defaultValue: "Size, More filters",
           condition: "enableFilter.eq.true",
+          helpText: "Comma-separated list of filters to display as buttons",
         },
       ],
     },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,6 +31,13 @@ export default {
           },
           to: { opacity: 1, transform: "translateX(0)" },
         },
+        "slide-down-and-fade": {
+          from: {
+            opacity: 0,
+            transform: "translateY(var(--bottom-distance, 6px))",
+          },
+          to: { opacity: 1, transform: "translateY(0)" },
+        },
         "enter-from-left": {
           from: { transform: "translateX(-100%)" },
           to: { transform: "translateX(0)" },
@@ -75,6 +82,8 @@ export default {
           "slide-up var(--slide-up-duration, .3s) cubic-bezier(0.87, 0, 0.13, 1) forwards",
         "slide-left-and-fade":
           "slide-left-and-fade var(--slide-left-and-fade-duration, .5s) cubic-bezier(.165,.84,.44,1) forwards",
+        "slide-down-and-fade":
+          "slide-down-and-fade var(--slide-down-and-fade-duration, .5s) cubic-bezier(.165,.84,.44,1) forwards",
         "enter-from-left":
           "enter-from-left var(--enter-from-left-duration, .3s) ease-out forwards",
         "enter-from-right":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `Checkbox` component to support flexible label content.
	- Added custom styling options to the `TooltipContent` component.
	- Introduced color swatch support in the `Filters` component.
	- New properties for customizable filter options in `CollectionFilters`.

- **Bug Fixes**
	- Improved rendering logic for filter labels and color swatches.

- **Chores**
	- Updated Tailwind CSS configuration with new animation keyframes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->