### PR TITLE
Remove hideUnavailableOptions from SingleProductData and schema

### DIFF
--- a/app/sections/single-product/index.tsx
+++ b/app/sections/single-product/index.tsx
@@ -32,7 +32,6 @@ import { SingleProductVariantSelector } from "./variant-selector";
 interface SingleProductData {
   productsCount: number;
   product: WeaverseProduct;
-  hideUnavailableOptions: boolean;
   showThumbnails: boolean;
 }
 
@@ -47,7 +46,6 @@ const SingleProduct = forwardRef<HTMLElement, SingleProductProps>(
       loaderData,
       children,
       product: _product,
-      hideUnavailableOptions,
       showThumbnails,
       ...rest
     } = props;
@@ -304,11 +302,6 @@ export const schema = createSchema({
           type: "product",
           name: "product",
           shouldRevalidate: true,
-        },
-        {
-          label: "Hide unavailable options",
-          type: "switch",
-          name: "hideUnavailableOptions",
         },
       ],
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Removed the option to hide unavailable product options in the single product section. This setting is no longer configurable or visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->