### PR TITLE
Switch versioning from semver to datetime-based (YYYY.M.D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026.3.16
+
+- [feature] Switch versioning from semver to datetime-based (`YYYY.M.D`)
+- [feature] Extract reviews API into separate route file
+- [fix] Return zero-state rating instead of null to prevent layout shift
+- [feature] Persist grid size preference to localStorage
+- [fix] Prevent vertical scrolling in swimlane component
+- [feature] Add country name display setting (short/full) to header
+
+---
+
+> Versioning switched from semver to datetime-based (YYYY.M.D) on 2026.3.16.
+> Entries below this line use the previous format.
+
+---
+
 ## 7.2.0
 
 ### Minor Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to Pilot
+
+## Versioning Convention
+
+Pilot uses **datetime-based versioning**: `YYYY.M.D`
+
+### Format
+
+- **Standard release**: `2026.3.16`
+- **Multiple same-day releases**: `2026.3.16-2`, `2026.3.16-3`
+
+### Why not semver?
+
+Pilot is a **theme that gets forked** by clients, not a library that gets installed. Semver's major/minor/patch distinctions give false compatibility signals — any change can conflict with client customizations. Datetime versioning is honest: it tells you exactly when the upstream snapshot was taken and how far behind you are.
+
+### Changelog entries
+
+Every release must have entries in `CHANGELOG.md` using these tags:
+
+- `[breaking]` — Changes that may require client action (renamed settings, removed sections, changed data shapes)
+- `[feature]` — New functionality (new sections, settings, integrations)
+- `[fix]` — Bug fixes and corrections
+
+Example:
+
+```markdown
+## 2026.3.16
+
+- [feature] Add country name display setting to header
+- [fix] Prevent vertical scrolling in swimlane component
+- [breaking] Rename `filtersPosition` setting values
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weaverse/pilot",
-  "version": "8.2.0",
+  "version": "2026.3.16",
   "description": "A production-ready Shopify storefront built with Hydrogen and Weaverse",
   "keywords": [
     "shopify",


### PR DESCRIPTION
## Summary

Release `2026.3.16` — switches versioning from semver to datetime-based and includes all changes from this development cycle.

### Versioning
- Switch `package.json` version from semver (`8.2.0`) to datetime-based (`2026.3.16`)
- Add separator in `CHANGELOG.md` marking the convention switch
- New changelog entries use `[breaking]`, `[feature]`, `[fix]` tags going forward
- Create `CONTRIBUTING.md` documenting the versioning convention

### Changes included in 2026.3.16
- [feature] Extract reviews API into separate route file (`routes/api/reviews.ts`)
- [feature] Persist grid size preference to localStorage via zustand persist
- [feature] Add country name display setting (short/full) to header
- [fix] Return zero-state rating instead of null to prevent layout shift
- [fix] Prevent vertical scrolling in swimlane component
- [fix] Render empty wrapper instead of null for non-bundle products

Closes https://github.com/Weaverse/builder/issues/2145