### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -3,7 +3,7 @@ import { StrictMode, startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
-if (!window.location.origin.includes("webcache.googleusercontent.com")) {
+if (window.location.hostname !== "webcache.googleusercontent.com") {
   startTransition(() => {
     const existingNonce =
       document.querySelector<HTMLScriptElement>("script[nonce]")?.nonce;


### PR DESCRIPTION
Potential fix for [https://github.com/Weaverse/pilot/security/code-scanning/1](https://github.com/Weaverse/pilot/security/code-scanning/1)

In general, instead of using `String.prototype.includes` to test whether a URL or origin matches some host, you should parse the URL and compare the host (or origin) against an explicit, exact whitelist. For browser code, `window.location.origin` and `window.location.hostname` are already parsed pieces of the current URL and should be compared using strict equality to the allowed value(s).

In this specific file, the intention is to avoid running the React hydration when the app is being viewed via Google’s web cache at `https://webcache.googleusercontent.com`. The current check:

```ts
if (!window.location.origin.includes("webcache.googleusercontent.com")) {
```

should be replaced with a precise comparison on the hostname (or origin). To preserve existing behavior while tightening security, we can explicitly check that `window.location.hostname` is exactly `webcache.googleusercontent.com`. That way, any origin like `https://webcache.googleusercontent.com` or `http://webcache.googleusercontent.com` will still be blocked, but `https://evil-webcache.googleusercontent.com.attacker.com` will not. No additional imports are required; `window.location` is a standard browser API.

Concretely: in `app/entry.client.tsx`, line 6 should be changed to use `window.location.hostname !== "webcache.googleusercontent.com"` (or the positive comparison with a negation) instead of `origin.includes(...)`. No other lines need modification.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
