### PR TITLE
fix: wrap Layout with withWeaverse for singleton ThemeSettingsStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ pnpm-lock.yaml
 .weaverse/autoperf/exp_*.json
 .weaverse/autoperf/baseline_*.json
 .weaverse/autoperf/wrangler.toml
+.claude/settings.local.json

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -97,7 +97,7 @@ export function ErrorBoundary({ error }: { error: Error }) {
   );
 }
 
-export function Layout({ children }: { children: React.ReactNode }) {
+export const Layout = withWeaverse(function Layout({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   const nonce = useNonce();
   const data = useRouteLoaderData<RootLoader>("root");
@@ -168,6 +168,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
       </body>
     </html>
   );
-}
+});
 
-export default withWeaverse(App);
+export default App;

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@shopify/hydrogen": "^2026.1.2",
         "@shopify/hydrogen-react": "^2026.1.1",
         "@tailwindcss/vite": "^4.2.2",
-        "@weaverse/hydrogen": "^5.10.1",
+        "@weaverse/hydrogen": "^5.11.0",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "colord": "2.9.3",
@@ -47,7 +47,6 @@
         "swiper": "^12.1.2",
         "tailwind-merge": "3.5.0",
         "tiny-invariant": "1.3.3",
-        "typographic-base": "1.0.4",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -5300,6 +5299,64 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
@@ -5458,23 +5515,23 @@
       "license": "MIT"
     },
     "node_modules/@weaverse/core": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@weaverse/core/-/core-5.10.1.tgz",
-      "integrity": "sha512-OWPhIics2FQG/rRC3RsN9wAecec5akhpK7zEWB9HzAqyG58YAfm6WUQ/mXu8fDc7cQFI/olohPnxx9vm5Z40zA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@weaverse/core/-/core-5.11.0.tgz",
+      "integrity": "sha512-xjYokdYvfyLEUYOl+2bTIGvuQ9eL+xvMfp5Q+CaVC6DM8MBMOMgE1h/c7kBe48R6xbHvrWa1gp1JgAFxST3log==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@weaverse/hydrogen": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@weaverse/hydrogen/-/hydrogen-5.10.1.tgz",
-      "integrity": "sha512-Nj6/2OND5jgqNrs+d1k6uiPkbs+Yhk0fAI2KhpMkmQ3NPrEq3W6v17eBrAVRu2i5F9i46NNDJKStVHeXhoMQwQ==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@weaverse/hydrogen/-/hydrogen-5.11.0.tgz",
+      "integrity": "sha512-M0cZM5LF6uHJO2Xf9WCSDFJa/pwOMLSupFmkKpnJpDp4+NEsLh8/2dTwGOzGoNqQhG/OXSk+L9Gna0E9nDg5pw==",
       "license": "MIT",
       "dependencies": {
         "@shopify/hydrogen": ">=2025.5",
         "@shopify/remix-oxygen": "3",
-        "@weaverse/react": "5.10.1",
+        "@weaverse/react": "5.11.0",
         "@weaverse/schema": "0.8.2",
         "react": ">=19",
         "react-dom": ">=19",
@@ -5486,12 +5543,12 @@
       }
     },
     "node_modules/@weaverse/react": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@weaverse/react/-/react-5.10.1.tgz",
-      "integrity": "sha512-Z/3p3MAqOhTSU+0mj31CTcg2n0gpKbeeGuTqVWRzVwpCM999ji9UmrKMqTklyqECvECuYhH/MZi6Go6XSxqdXA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@weaverse/react/-/react-5.11.0.tgz",
+      "integrity": "sha512-mM+UXvdC98TGM0NYbUcfAh9hI3NpShZd+zMAi8H1TgZxb9VAw+biCnC4W1O8tF7CismnGXC75eOhe390lrOZCQ==",
       "license": "MIT",
       "dependencies": {
-        "@weaverse/core": "5.10.1",
+        "@weaverse/core": "5.11.0",
         "clsx": "^2.1.1",
         "react": ">=19",
         "react-dom": ">=19"
@@ -10332,12 +10389,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/textr": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/textr/-/textr-0.3.0.tgz",
-      "integrity": "sha512-yQrF3w9ThyNvyJjkpFTwBpsVxRQ4870xHg2fue1xeK1J1EZIx5cV7XPW6Fwi/XNC0du/3t9CNWZvlHUfCxPpPg==",
-      "license": "MIT"
-    },
     "node_modules/throttle-debounce": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
@@ -10556,125 +10607,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/typographic-apostrophes": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/typographic-apostrophes/-/typographic-apostrophes-1.1.1.tgz",
-      "integrity": "sha512-3/05j0vg9osPy4whnihGaudPLwNxuyczO3AYmsVeLUBUq/aKhbSfbjVPx1VzV7Rwpkbl0vf9qOwOLP6CgfRWZg==",
-      "license": "MIT"
-    },
-    "node_modules/typographic-apostrophes-for-possessive-plurals": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/typographic-apostrophes-for-possessive-plurals/-/typographic-apostrophes-for-possessive-plurals-1.0.5.tgz",
-      "integrity": "sha512-sBUA/sFTAFFjd/ey9Xtld1cq2fXCZJ0tQHmlDovttMC9D1WJDOt2f49b9DxA0Yk2iK3yoDFm0HQAs/mKO24sDg==",
-      "license": "MIT"
-    },
-    "node_modules/typographic-arrows": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typographic-arrows/-/typographic-arrows-1.0.3.tgz",
-      "integrity": "sha512-RlmhHjxOSQ9QjWQbdHFPb+B54hVQLxwWvbO+liqy5NN0naLUzqnZumYH3V/RrR9Xf6cpAZvxKdmwYzpozlx2Ug==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT"
-    },
-    "node_modules/typographic-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typographic-base/-/typographic-base-1.0.4.tgz",
-      "integrity": "sha512-R2ABy+ohOfZAKumZkkTmP11NWqj0AG7nZg3yyvnuzzl+D0GL9Gu8jO2+D/oAD+04z+/z0AesMO/rncBooHUs7g==",
-      "license": "MIT",
-      "dependencies": {
-        "textr": "^0.3.0",
-        "typographic-apostrophes": "^1.1.1",
-        "typographic-apostrophes-for-possessive-plurals": "^1.0.5",
-        "typographic-arrows": "^1.0.0",
-        "typographic-copyright": "^1.0.1",
-        "typographic-currency": "^1.1.0",
-        "typographic-ellipses": "^1.0.11",
-        "typographic-em-dashes": "^1.0.2",
-        "typographic-en-dashes": "^1.0.1",
-        "typographic-math-symbols": "^1.1.5",
-        "typographic-quotes": "^1.2.1",
-        "typographic-registered-trademark": "^1.0.1",
-        "typographic-single-spaces": "^1.0.2",
-        "typographic-trademark": "^1.0.1"
-      }
-    },
-    "node_modules/typographic-copyright": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typographic-copyright/-/typographic-copyright-1.0.1.tgz",
-      "integrity": "sha512-DSx9fojOVoBhtYw5Zh0r9ShFWgjuMwUH615l21OXDbi3m2Fl/bBT5yMoZjbZzuJ51kiF66CnTTfJP5Zu5zVZMg==",
-      "license": "MIT"
-    },
-    "node_modules/typographic-currency": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/typographic-currency/-/typographic-currency-1.1.2.tgz",
-      "integrity": "sha512-adlN4VO5DwYSx2kxfj1AMmx+FGHn6ShFS3qip0Q3VwBD7tSENE4XUbs22b9hlK9g4thw8mZsLyXS3ca799gYhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "typographic-currency-db": "1.0.0"
-      }
-    },
-    "node_modules/typographic-currency-db": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typographic-currency-db/-/typographic-currency-db-1.0.0.tgz",
-      "integrity": "sha512-jWu0u9P4mmpZ+e62f/GHrSKUpwS4WmNxGsSI3ZrZZYmfJlmtjA+WkIt+RvpmM0H8ZzyyFzOYRifV5UbxoeTcAw==",
-      "license": "MIT"
-    },
-    "node_modules/typographic-ellipses": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/typographic-ellipses/-/typographic-ellipses-1.0.11.tgz",
-      "integrity": "sha512-TN83hcvDfvPFxqyWTe4ascexSj1wxuzafnXrLS7cZZq5ZEeHYQPE4UXP15mZnsNg71ysnOJxdNXWckxqeTVMAQ==",
-      "license": "MIT"
-    },
-    "node_modules/typographic-em-dashes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typographic-em-dashes/-/typographic-em-dashes-1.0.2.tgz",
-      "integrity": "sha512-9aCk1Crubx0YCWsj2PJCD7PIIpx6dBdyOogPL5lOQuH2gIyZtSMp7OGt7SCcpn0BxbToIal2t38SnSOhsagU9A==",
-      "license": "MIT"
-    },
-    "node_modules/typographic-en-dashes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typographic-en-dashes/-/typographic-en-dashes-1.0.1.tgz",
-      "integrity": "sha512-/Zaf64q0tCJZ4yxAbBVUmogPB1pV2upiQ6v3aU3kvU+HxEC8szXmRFA6wDTUkAP6YVrnDYgHlUaLzUvKcFUSiw==",
-      "license": "MIT"
-    },
-    "node_modules/typographic-math-symbols": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/typographic-math-symbols/-/typographic-math-symbols-1.1.5.tgz",
-      "integrity": "sha512-GBYbJzZbERHZJ9eflsqFQMfZDBJGCkguMXVbWerG1PkyndNFOA6fYR1H+jUh9JSobr7ir/C92QJ+7LrcBsAbVw==",
-      "license": "MIT"
-    },
-    "node_modules/typographic-quotes": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/typographic-quotes/-/typographic-quotes-1.2.2.tgz",
-      "integrity": "sha512-rdbJx2ho7ovckr+Yd+zccU3UnTyS0U+lwEzBl0FoMMECewQn7ZM0tLMBWPEvOOHPHCiYaP2C0Wx9Lq1F+Ou8yg==",
-      "license": "MIT",
-      "dependencies": {
-        "typographic-quotes-l10n-db": "^1.0.0"
-      }
-    },
-    "node_modules/typographic-quotes-l10n-db": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typographic-quotes-l10n-db/-/typographic-quotes-l10n-db-1.0.0.tgz",
-      "integrity": "sha512-E9/XSBJWtmax9XkFlLwqbNW5wNFBbLhL2CDYShmQ/Kw87wL9TwKU36j8SON7Ro0K2GF+RjfcYb/SdUN3XqZkvg==",
-      "license": "MIT"
-    },
-    "node_modules/typographic-registered-trademark": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typographic-registered-trademark/-/typographic-registered-trademark-1.0.1.tgz",
-      "integrity": "sha512-pxjY5hicdCH+VPEzqgoYlQD9ZXMqaJZgOLrAweIzBl19hs6SLLdf8CD0kXF6jv9s4QRCjTl/uiaoVkid6paI9Q==",
-      "license": "MIT"
-    },
-    "node_modules/typographic-single-spaces": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typographic-single-spaces/-/typographic-single-spaces-1.0.2.tgz",
-      "integrity": "sha512-OTfrg6zmAx2XXaaXywdFfFIJ/w2e2/DZdRwBK+IqJHjEEzN0C1QtQ7kkOCW/Rdf04S1K639Wcb3y5OPVlP4zew==",
-      "license": "MIT"
-    },
-    "node_modules/typographic-trademark": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typographic-trademark/-/typographic-trademark-1.0.1.tgz",
-      "integrity": "sha512-d+vFEiagUVltY/cFD2wzATb1YZvOvx+SmxHtCq1QLc22mImkpAccOD826d6eRCUFx75eGhsE3nWjNKOsis2Ibg==",
-      "license": "MIT"
     },
     "node_modules/unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@shopify/hydrogen": "^2026.1.2",
     "@shopify/hydrogen-react": "^2026.1.1",
     "@tailwindcss/vite": "^4.2.2",
-    "@weaverse/hydrogen": "^5.10.1",
+    "@weaverse/hydrogen": "^5.11.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "colord": "2.9.3",


### PR DESCRIPTION
## Summary
- Move `withWeaverse()` from `App` to `Layout` so the `ThemeSettingsStore` context covers the entire component tree — including Layout itself where `useThemeSettings()` is called
- Bump `@weaverse/hydrogen` to `^5.11.0` which provides the singleton store via React Context

## Related
- Weaverse SDK PR: https://github.com/Weaverse/weaverse/pull/441
- SDK Release: https://github.com/Weaverse/weaverse/releases/tag/v5.11.0

## Test plan
- [ ] Verify no "Cannot update component while rendering" React warning
- [ ] Verify theme settings work on initial load and client-side navigation
- [ ] Verify `useThemeSettings()` returns consistent data across components