### PR TITLE
feat: integrate Shopify <shopify-account> web component

### DIFF
--- a/.weaverse/specs/2026-04-07--shopify-account-web-component/README.md
+++ b/.weaverse/specs/2026-04-07--shopify-account-web-component/README.md
@@ -1,0 +1,20 @@
+# Feature: Shopify Account Web Component
+
+| Field            | Value                                                    |
+| ---------------- | -------------------------------------------------------- |
+| **Status**       | in-progress                                              |
+| **Owner**        | @paul-phan                                               |
+| **Created**      | 2026-04-07                                               |
+| **Last Updated** | 2026-04-07                                               |
+
+## Original Prompt
+
+> Integrate Shopify's new `<shopify-account>` web component into the Pilot Hydrogen storefront so customers can sign in/manage account without leaving storefront UX.
+>
+> Reference: https://shopify.dev/docs/storefronts/headless/bring-your-own-stack/hydrogen-with-account-component
+>
+> — [Weaverse/pilot#342](https://github.com/Weaverse/pilot/issues/342)
+
+## Summary
+
+Replace the existing `AccountLink` icon-button in Pilot's header with Shopify's native `<shopify-account>` web component. This provides inline sign-in and account management without leaving the storefront UX. Hard replace with no theme toggle — Hydrogen 2026.1.2 supports all required APIs (`getAccessToken()`), no login parameter patching needed.

--- a/.weaverse/specs/2026-04-07--shopify-account-web-component/plan.md
+++ b/.weaverse/specs/2026-04-07--shopify-account-web-component/plan.md
@@ -1,0 +1,178 @@
+# Implementation Plan
+
+## Context
+
+- **Hydrogen version**: 2026.1.2 (supports `getAccessToken()`, no login param patch needed)
+- **Current state**: Header renders a `UserIcon` linking to `/account`. Auth uses Hydrogen's `customerAccount` API via OAuth.
+- **Reference**: [Shopify docs](https://shopify.dev/docs/storefronts/headless/bring-your-own-stack/hydrogen-with-account-component)
+- **Approach**: Root Loader + Head Script — follow Shopify's official pattern exactly
+
+## Data Flow
+
+```
+root loader
+  ├─ critical: publicStoreDomain (new field from env)
+  │            publicAccessToken = consent.storefrontAccessToken (reuse existing)
+  └─ deferred: customerAccessToken (via getAccessToken() → string | undefined)
+       │
+       ▼
+Layout (<head>)
+  └─ <script nonce={nonce} src="cdn.shopify.com/.../account.js" />
+       │
+       ▼
+Header
+  └─ <shopify-store store-domain=... public-access-token=... customer-access-token=...>
+       └─ <shopify-account sign-in-url="/account/login" />
+```
+
+## Files and Folders Touched
+
+| File | Type | Description |
+|------|------|-------------|
+| `app/.server/root.ts` | Modified | Add `publicStoreDomain` to critical data, `customerAccessToken` to deferred |
+| `app/root.tsx` | Modified | Add script tag in `<head>` with nonce |
+| `app/components/layout/header.tsx` | Modified | Replace AccountLink with ShopifyAccountButton |
+| `app/weaverse/csp.ts` | Modified | Add `scriptSrc` for cdn.shopify.com |
+| `app/types/shopify-account.d.ts` | New | React.JSX module augmentation for custom elements |
+
+## Steps
+
+### Step 1: TypeScript declarations (`app/types/shopify-account.d.ts`)
+
+Create new file. Since `tsconfig.json` uses `"jsxImportSource": "react"`, must use React.JSX module augmentation (not global `JSX` namespace):
+
+```typescript
+import type React from "react";
+
+declare module "react" {
+  namespace JSX {
+    interface IntrinsicElements {
+      "shopify-store": React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          "store-domain"?: string;
+          "public-access-token"?: string;
+          "customer-access-token"?: string;
+        },
+        HTMLElement
+      >;
+      "shopify-account": React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          "sign-in-url"?: string;
+        },
+        HTMLElement
+      >;
+    }
+  }
+}
+```
+
+### Step 2: Root loader tokens (`app/.server/root.ts`)
+
+In `loadCriticalData`, add to the return object:
+
+```typescript
+publicStoreDomain: env.PUBLIC_STORE_DOMAIN,
+```
+
+In `loadDeferredData`, add to the return object:
+
+```typescript
+customerAccessToken: customerAccount.getAccessToken(),
+```
+
+Note: `getAccessToken()` returns `Promise<string | undefined>`. The `publicAccessToken` is already available as `consent.storefrontAccessToken` — no duplication needed.
+
+### Step 3: CSP update (`app/weaverse/csp.ts`)
+
+Add `scriptSrc` as a new key in the existing `updatedCsp` object literal:
+
+```typescript
+scriptSrc: ["https://cdn.shopify.com"],
+```
+
+Hydrogen's `createContentSecurityPolicy` merges this with its defaults.
+
+### Step 4: Script in head (`app/root.tsx`)
+
+Add after `<GlobalStyle />` in the `<head>` block of the `Layout` component. Must include `nonce` (already available in Layout via `useNonce()`):
+
+```tsx
+<script
+  type="module"
+  src="https://cdn.shopify.com/storefront/web-components/account.js"
+  async
+  nonce={nonce}
+/>
+```
+
+### Step 5: Replace header AccountLink (`app/components/layout/header.tsx`)
+
+Remove the `AccountLink` function. Replace its usage with `ShopifyAccountButton`:
+
+```tsx
+function ShopifyAccountButton() {
+  let rootData = useRouteLoaderData<RootLoader>("root");
+  let publicStoreDomain = rootData?.publicStoreDomain;
+  let publicAccessToken = rootData?.consent?.storefrontAccessToken;
+
+  return (
+    <Suspense fallback={<UserIcon className="h-5 w-5" />}>
+      <Await
+        resolve={rootData?.customerAccessToken}
+        errorElement={<UserIcon className="h-5 w-5" />}
+      >
+        {(customerAccessToken) => (
+          <shopify-store
+            store-domain={publicStoreDomain}
+            public-access-token={publicAccessToken}
+            {...(customerAccessToken
+              ? { "customer-access-token": customerAccessToken }
+              : {})}
+          >
+            <shopify-account sign-in-url="/account/login" />
+          </shopify-store>
+        )}
+      </Await>
+    </Suspense>
+  );
+}
+```
+
+Key details:
+- Reuses `consent.storefrontAccessToken` — no duplicate field
+- Spread guard prevents passing `"undefined"` string when not logged in
+- `errorElement` falls back to UserIcon if token promise rejects
+- `sign-in-url="/account/login"` aligns with existing `app/routes/account/auth/login.ts`
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| Unauthenticated user | `customer-access-token` omitted via spread guard; web component shows sign-in CTA |
+| Weaverse design mode | Web component renders but sign-in clicks won't work in iframe; acceptable, matches other interactive Shopify components |
+| SSR / Hydration | Custom elements render as empty on server and client alike; no hydration mismatch |
+| Script not yet loaded | Custom elements render empty; Suspense fallback shows UserIcon during Await resolution |
+
+## Not In Scope
+
+- Login parameter patching (Hydrogen 2026.1.2 handles natively)
+- Theme setting toggle (hard replace)
+- New routes or auth flow changes
+- New npm dependencies
+
+## Testing
+
+- Deploy to Oxygen staging (does not work on localhost)
+- Verify account sign-in button renders in header
+- Validate login → callback → redirect flow
+- Verify authenticated state persists across navigation
+- Verify no regressions to header nav, cart, search
+- Test on mobile viewport
+- Verify no hydration mismatch warnings in console
+
+## Acceptance Criteria
+
+- Account CTA uses Shopify account web component in header
+- No redirect to legacy account pages for sign-in
+- Auth flow works end-to-end on Oxygen
+- No regressions to header nav/cart/search

--- a/app/.server/root.ts
+++ b/app/.server/root.ts
@@ -43,6 +43,7 @@ export async function loadCriticalData({
     selectedLocale: storefront.i18n,
     weaverseTheme,
     googleGtmID: env.PUBLIC_GOOGLE_GTM_ID,
+    publicStoreDomain: env.PUBLIC_STORE_DOMAIN,
   };
 }
 
@@ -55,9 +56,9 @@ export function loadDeferredData({ context }: LoaderFunctionArgs) {
   const { cart, customerAccount } = context;
 
   return {
-    isLoggedIn: customerAccount.isLoggedIn(),
     cart: cart.get(),
     swatchesConfigs: getSwatchesConfigs(context),
+    customerAccessToken: customerAccount.getAccessToken(),
   };
 }
 

--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -1,7 +1,6 @@
 import { MagnifyingGlassIcon, UserIcon } from "@phosphor-icons/react";
 import { useThemeSettings } from "@weaverse/hydrogen";
 import { cva } from "class-variance-authority";
-import clsx from "clsx";
 import { Suspense } from "react";
 import {
   Await,
@@ -104,7 +103,7 @@ export function Header() {
         <div className="z-1 flex items-center gap-1">
           {showHeaderCountrySelector && <HeaderCountrySelector />}
           <PredictiveSearchButton />
-          <AccountLink className="relative flex h-8 w-8 items-center justify-center" />
+          <ShopifyAccountButton />
           <CartDrawer />
         </div>
       </div>
@@ -112,26 +111,27 @@ export function Header() {
   );
 }
 
-function AccountLink({ className }: { className?: string }) {
-  const rootData = useRouteLoaderData<RootLoader>("root");
-  const isLoggedIn = rootData?.isLoggedIn;
+function ShopifyAccountButton() {
+  let rootData = useRouteLoaderData<RootLoader>("root");
+  let publicStoreDomain = rootData?.publicStoreDomain;
+  let publicAccessToken = rootData?.consent?.storefrontAccessToken;
 
   return (
-    <Link to="/account" className={clsx("transition-none", className)}>
-      <Suspense fallback={<UserIcon className="h-5 w-5" />}>
-        <Await
-          resolve={isLoggedIn}
-          errorElement={<UserIcon className="h-5 w-5" />}
-        >
-          {(loggedIn) =>
-            loggedIn ? (
-              <UserIcon className="h-5 w-5" />
-            ) : (
-              <UserIcon className="h-5 w-5" />
-            )
-          }
-        </Await>
-      </Suspense>
-    </Link>
+    <Suspense fallback={<UserIcon className="h-5 w-5" />}>
+      <Await
+        resolve={rootData?.customerAccessToken}
+        errorElement={<UserIcon className="h-5 w-5" />}
+      >
+        {(customerAccessToken) => (
+          <shopify-store
+            store-domain={publicStoreDomain}
+            public-access-token={publicAccessToken}
+            customer-access-token={customerAccessToken || undefined}
+          >
+            <shopify-account sign-in-url="/account/login" />
+          </shopify-store>
+        )}
+      </Await>
+    </Suspense>
   );
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -123,6 +123,12 @@ export const Layout = withWeaverse(function Layout({ children }: { children: Rea
         <Meta />
         <Links />
         <GlobalStyle />
+        <script
+          type="module"
+          src="https://cdn.shopify.com/storefront/web-components/account.js"
+          async
+          nonce={nonce}
+        />
       </head>
       <body
         style={

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -61,7 +61,7 @@ export default hydrogenRoutes([
         index("routes/account/dashboard/index.tsx"),
         route("profile", "routes/account/profile.tsx"),
         route("edit", "routes/account/edit.tsx"),
-        route("addresses", "routes/account/address/list.tsx"),
+        route("addr", "routes/account/address/list.tsx"),
         route("address/:id", "routes/account/address/index.tsx"),
         ...prefix("orders", [
           index("routes/account/orders/list.tsx"),

--- a/app/types/shopify-account.d.ts
+++ b/app/types/shopify-account.d.ts
@@ -1,0 +1,22 @@
+import type React from "react";
+
+declare module "react" {
+  namespace JSX {
+    interface IntrinsicElements {
+      "shopify-store": React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          "store-domain"?: string;
+          "public-access-token"?: string;
+          "customer-access-token"?: string;
+        },
+        HTMLElement
+      >;
+      "shopify-account": React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          "sign-in-url"?: string;
+        },
+        HTMLElement
+      >;
+    }
+  }
+}

--- a/app/weaverse/csp.ts
+++ b/app/weaverse/csp.ts
@@ -31,6 +31,7 @@ export function getWeaverseCsp(
     ],
     connectSrc: ["vimeo.com", "*.google-analytics.com", ...weaverseHosts],
     styleSrc: weaverseHosts,
+    scriptSrc: ["https://cdn.shopify.com"],
   };
   if (isDesignMode) {
     updatedCsp.frameAncestors = ["*"];


### PR DESCRIPTION
## Summary
- Replace custom `AccountLink` with Shopify's native `<shopify-account>` web component for inline sign-in/account management in header
- Load `account.js` bundle from Shopify CDN with nonce and CSP allowlist
- Pass `publicStoreDomain` and `customerAccessToken` from root loader to the web component
- Rename `/account/addresses` route to `/account/addr` so the web component's hardcoded Profile link falls through to catch-all → redirects to `/account` dashboard
- Remove dead `isLoggedIn` deferred data (no longer consumed after AccountLink removal)
- Add TypeScript declarations for `<shopify-store>` and `<shopify-account>` custom elements

## Files changed
| File | Change |
|------|--------|
| `app/.server/root.ts` | Add `publicStoreDomain` (critical), `customerAccessToken` (deferred); remove dead `isLoggedIn` |
| `app/root.tsx` | Add script tag for account.js with nonce |
| `app/components/layout/header.tsx` | Replace `AccountLink` with `ShopifyAccountButton` |
| `app/weaverse/csp.ts` | Add `scriptSrc` for cdn.shopify.com |
| `app/routes.ts` | Rename `addresses` → `addr` route |
| `app/types/shopify-account.d.ts` | New — JSX type declarations for custom elements |

## Test plan
- [ ] Deploy to Oxygen staging (does not work on localhost)
- [ ] Verify account sign-in button renders in header
- [ ] Click Profile in account dropdown → should redirect to `/account` dashboard
- [ ] Validate login → callback → redirect flow end-to-end
- [ ] Verify authenticated state persists across navigation
- [ ] Verify no regressions to header nav, cart, search
- [ ] Test on mobile viewport
- [ ] Verify `/account/addr` renders address list correctly

Closes Weaverse/pilot#142