### PR TITLE
chore: release v2026.4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weaverse/pilot",
-  "version": "2026.3.31",
+  "version": "2026.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weaverse/pilot",
-      "version": "2026.3.31",
+      "version": "2026.4.7",
       "license": "MIT",
       "dependencies": {
         "@fontsource-variable/cabin": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weaverse/pilot",
-  "version": "2026.3.31",
+  "version": "2026.4.7",
   "description": "A production-ready Shopify storefront built with Hydrogen and Weaverse",
   "keywords": [
     "shopify",


### PR DESCRIPTION
## Release v2026.4.7

Version bump for Pilot template.

### Changes since v2026.3.31
- **feat**: Integrate Shopify `<shopify-account>` web component in header (#342)
- **perf**: Add Vite manualChunks splitting and extract static heading CSS (#368)
- **fix**: Wrap Layout with withWeaverse for singleton ThemeSettingsStore (#366)