### PR TITLE
feat(hydrogen): fetchCustomPages for sitemap support

### DIFF
--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -473,6 +473,15 @@ export type ProjectIdValidationResult = {
   error?: string
 }
 
+export interface CustomPageEntry {
+  changeFrequency?: 'daily' | 'weekly' | 'monthly'
+  handle: string
+  lastModified: string
+  locale: string | null
+  path: string
+  priority?: number
+}
+
 /**
  * Type guards for response validation
  */

--- a/packages/hydrogen/src/weaverse-client.ts
+++ b/packages/hydrogen/src/weaverse-client.ts
@@ -6,6 +6,7 @@ import {
 } from '@shopify/hydrogen'
 import type {
   CachingStrategy,
+  CustomPageEntry,
   FetchProjectPayload,
   FetchProjectRequestBody,
   HydrogenComponent,
@@ -750,6 +751,56 @@ export class WeaverseClient {
         },
       ],
     }
+  }
+
+  /**
+   * Fetch all published custom pages for sitemap generation.
+   * Paginates automatically, never throws, returns accumulated results on partial failure.
+   */
+  async fetchCustomPages(opts?: {
+    locale?: string
+    limit?: number
+  }): Promise<CustomPageEntry[]> {
+    const { weaverseHost, projectId } = this.configs
+    const entries: CustomPageEntry[] = []
+    const MAX_PAGES = 100
+
+    let cursor: string | null = null
+
+    for (let i = 0; i < MAX_PAGES; i++) {
+      const params = new URLSearchParams()
+      if (opts?.locale) params.set('locale', opts.locale)
+      if (opts?.limit) params.set('limit', String(opts.limit))
+      if (cursor) params.set('cursor', cursor)
+
+      const qs = params.toString()
+      const url = `${weaverseHost}/api/public/v1/projects/${projectId}/custom-pages${qs ? `?${qs}` : ''}`
+
+      try {
+        const result = await this.fetchWithCache<{
+          data: CustomPageEntry[]
+          nextCursor: string | null
+        }>(url)
+        entries.push(...(result.data || []))
+
+        if (!result.nextCursor) return entries
+        cursor = result.nextCursor
+      } catch (err: any) {
+        const status = err?.status
+        const msg = err?.message || String(err)
+        console.warn(
+          entries.length === 0
+            ? `[Weaverse] Failed to fetch custom pages: ${msg}${status ? ` (HTTP ${status})` : ''}`
+            : `[Weaverse] Custom pages pagination interrupted: ${msg}`
+        )
+        return entries
+      }
+    }
+
+    console.warn(
+      '[Weaverse] Custom pages pagination cap reached (100 iterations)'
+    )
+    return entries
   }
 
   /**

--- a/packages/hydrogen/test/weaverse-client-custom-pages.test.ts
+++ b/packages/hydrogen/test/weaverse-client-custom-pages.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, spyOn } from 'bun:test'
+import type { CustomPageEntry } from '../src/types'
+
+type ApiResponse = { data: CustomPageEntry[]; nextCursor: string | null }
+
+function makeClient(fetchImpl: (url: string) => Promise<Response>) {
+  return {
+    configs: {
+      weaverseHost: 'https://builder.weaverse.io',
+      projectId: 'test-project-id',
+    },
+    fetchWithCache: async (url: string) => {
+      const res = await fetchImpl(url)
+      if (!res.ok) {
+        const err = new Error(`HTTP ${res.status}`)
+        ;(err as any).status = res.status
+        throw err
+      }
+      return res.json()
+    },
+  }
+}
+
+const { WeaverseClient } = await import('../src/weaverse-client')
+
+function fetchPages(
+  client: ReturnType<typeof makeClient>,
+  opts?: { locale?: string; limit?: number }
+) {
+  return WeaverseClient.prototype.fetchCustomPages.call(client, opts)
+}
+
+const ENTRY: CustomPageEntry = {
+  handle: 'about',
+  locale: null,
+  path: '/about',
+  lastModified: '2026-04-01T10:00:00.000Z',
+  priority: 0.7,
+  changeFrequency: 'weekly',
+}
+
+describe('fetchCustomPages', () => {
+  it('returns parsed entries on success', async () => {
+    const client = makeClient(() =>
+      Promise.resolve(
+        Response.json({ data: [ENTRY], nextCursor: null })
+      )
+    )
+    expect(await fetchPages(client)).toEqual([ENTRY])
+  })
+
+  it('returns [] for empty data', async () => {
+    const client = makeClient(() =>
+      Promise.resolve(
+        Response.json({ data: [], nextCursor: null })
+      )
+    )
+    expect(await fetchPages(client)).toEqual([])
+  })
+
+  it('returns [] and warns on network error', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+    const client = makeClient(() =>
+      Promise.reject(new Error('Network failure'))
+    )
+    expect(await fetchPages(client)).toEqual([])
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('returns [] and warns with status on 404', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+    const client = makeClient(() =>
+      Promise.resolve(new Response('Not found', { status: 404 }))
+    )
+    expect(await fetchPages(client)).toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('404'))
+    warnSpy.mockRestore()
+  })
+
+  it('appends locale param to URL', async () => {
+    let capturedUrl = ''
+    const client = makeClient((url) => {
+      capturedUrl = url
+      return Promise.resolve(
+        Response.json({ data: [], nextCursor: null })
+      )
+    })
+    await fetchPages(client, { locale: 'fr' })
+    expect(capturedUrl).toContain('locale=fr')
+  })
+
+  it('returns accumulated entries when later page fails', async () => {
+    const cursor = btoa('1000:some-id')
+    let callCount = 0
+    const client = makeClient(() => {
+      callCount++
+      if (callCount === 1) {
+        return Promise.resolve(
+          Response.json({ data: [ENTRY], nextCursor: cursor })
+        )
+      }
+      return Promise.reject(new Error('Network failure on page 2'))
+    })
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+    const result = await fetchPages(client)
+    expect(result).toEqual([ENTRY])
+    warnSpy.mockRestore()
+  })
+
+  it('stops at pagination cap (100 iterations)', async () => {
+    let callCount = 0
+    const cursor = btoa('1000:id')
+    const client = makeClient(() => {
+      callCount++
+      return Promise.resolve(
+        Response.json({ data: [ENTRY], nextCursor: cursor })
+      )
+    })
+    await fetchPages(client)
+    expect(callCount).toBeLessThanOrEqual(100)
+  })
+
+  it('warns when pagination cap reached', async () => {
+    const cursor = btoa('1000:id')
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+    let callCount = 0
+    const client = makeClient(() => {
+      callCount++
+      return Promise.resolve(
+        Response.json({ data: [ENTRY], nextCursor: cursor })
+      )
+    })
+    const result = await fetchPages(client)
+    expect(result.length).toBeGreaterThan(0)
+    if (callCount >= 100) {
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('pagination cap')
+      )
+    }
+    warnSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- Add `CustomPageEntry` type for sitemap entries (handle, locale, path, lastModified, priority, changeFrequency)
- Add `fetchCustomPages()` method on `WeaverseClient` that wraps the new public builder endpoint (`/api/public/v1/projects/:projectId/custom-pages`)
- Method paginates automatically following `nextCursor`, caps at 100 iterations, never throws
- Returns accumulated entries on partial failure; logs warnings via `console.warn`

## Test plan
- [x] 8 unit tests (success, empty, network error, 404, locale param, partial failure, pagination cap, cap warning)
- [ ] Integration with pilot theme `sitemap-weaverse.xml.ts` (separate PR)
- [ ] Builder public endpoint already merged (PR #2226)