### PR TITLE
fix(web-components): use umbrella Storefront Web Components bundle

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -154,7 +154,7 @@ export const Layout = withWeaverse(function RootLayout({
         <GlobalStyle />
         <script
           type="module"
-          src="https://cdn.shopify.com/storefront/web-components/account.js"
+          src="https://cdn.shopify.com/storefront/web-components.js"
           async
           nonce={nonce}
         />


### PR DESCRIPTION
## What

Switch the Storefront Web Components script tag in `app/root.tsx` from the per-component bundle to the umbrella bundle:

```diff
- src="https://cdn.shopify.com/storefront/web-components/account.js"
+ src="https://cdn.shopify.com/storefront/web-components.js"
```

## Why

The per-component file registers ONLY `<shopify-account>`. Pilot today renders only that one component, so it works — but any custom section or future Pilot feature that adds a sibling component (`<shopify-store>`, `<shopify-product>`, `<shopify-context>`, `<shopify-data>`) silently fails: the tag remains undefined and the browser renders nothing in its slot. There's no console error to point at the cause.

This bites anyone trying to:

- Add a `<shopify-product>` quick-view from a custom section
- Use `<shopify-store store-domain>` as a parent context for multiple sub-components
- Migrate to Shopify's newer account UI patterns that bundle multiple components

The umbrella bundle registers every Storefront Web Component element from a single HTTP/2 stream. Gzipped size delta is negligible.

## Reference

[Shopify dev docs — Storefront Web Components](https://shopify.dev/docs/api/storefront-web-components) uses the umbrella bundle in all examples; the per-component file is an advanced opt-in for size-sensitive contexts.

## Risk

Minimal. The umbrella bundle is a strict superset — any storefront that worked with the per-component file continues to work, and additional component tags now resolve where they previously didn't.

## Verification

1. Open any page that renders the header → `<shopify-account>` still mounts and signs in / shows account icon correctly.
2. (Optional) Drop `<shopify-context country="US" language="EN"></shopify-context>` into a section and confirm it now registers (would have remained undefined before this change).