### PR TITLE
fix: support iOS inline hero video playback

### DIFF
--- a/app/sections/hero-video/index.tsx
+++ b/app/sections/hero-video/index.tsx
@@ -120,6 +120,25 @@ export default function HeroVideo(props: HeroVideoProps) {
       "video, iframe",
     ) as HTMLElement | null;
 
+    if (mediaEl instanceof HTMLVideoElement) {
+      mediaEl.muted = true;
+      mediaEl.defaultMuted = true;
+      mediaEl.playsInline = true;
+      mediaEl.setAttribute("muted", "");
+      mediaEl.setAttribute("playsinline", "");
+      mediaEl.setAttribute("webkit-playsinline", "");
+
+      if (playing) {
+        mediaEl.autoplay = true;
+        mediaEl.setAttribute("autoplay", "");
+      }
+
+      if (loop !== false) {
+        mediaEl.loop = true;
+        mediaEl.setAttribute("loop", "");
+      }
+    }
+
     if (mediaEl) {
       const actualHeight = mediaEl.getBoundingClientRect().height;
       if (actualHeight > 0) {
@@ -209,8 +228,10 @@ export default function HeroVideo(props: HeroVideoProps) {
             <ReactPlayer
               src={video?.url || videoURL}
               playing={playing}
+              autoPlay={playing}
               muted
               loop={loop !== false}
+              playsInline
               width={size.width}
               height={size.height}
               controls={false}


### PR DESCRIPTION
## Summary
- Add native `autoPlay` and `playsInline` attributes to the Hero Video ReactPlayer instance.
- Ensure the rendered HTML video element has `muted`, `defaultMuted`, `playsinline`, `webkit-playsinline`, `autoplay`, and `loop` attributes when applicable.
- Keeps mobile Safari and Chrome on iOS from opening or blocking background Hero Video playback because of missing inline autoplay attributes.

## Test Plan
- `npm run typecheck`
- `npx biome check app/sections/hero-video/index.tsx`
- `npm run build`

Note: `npm run biome` still fails on existing unrelated issues in `app/components/root/consent-banner.tsx`, `app/components/cart/cart-summary.tsx`, `app/sections/blog-post.tsx`, and `app/utils/checkout-attribution.ts`; the changed Hero Video file passes targeted Biome check.
