### PR TITLE
Fix cart locale preservation for market currencies

### DIFF
--- a/app/components/cart/cart-line-item.tsx
+++ b/app/components/cart/cart-line-item.tsx
@@ -12,6 +12,7 @@ import { Image } from "~/components/image";
 import { Link } from "~/components/link";
 import { RevealUnderline } from "~/components/reveal-underline";
 import { Skeleton } from "~/components/skeleton";
+import { usePrefixPathWithLocale } from "~/hooks/use-prefix-path-with-locale";
 import type { CartLayoutType } from "~/types/others";
 import { calculateAspectRatio } from "~/utils/image";
 import { CartLineQuantityAdjust } from "./cart-line-qty-adjust";
@@ -116,9 +117,11 @@ function ItemRemoveButton({
   lineId: CartLine["id"];
   className?: string;
 }) {
+  const cartRoute = usePrefixPathWithLocale("/cart");
+
   return (
     <CartForm
-      route="/cart"
+      route={cartRoute}
       action={CartForm.ACTIONS.LinesRemove}
       inputs={{ lineIds: [lineId] }}
       fetcherKey="cart-line-remove"

--- a/app/components/cart/cart-line-qty-adjust.tsx
+++ b/app/components/cart/cart-line-qty-adjust.tsx
@@ -8,6 +8,7 @@ import {
 import type { CartLineUpdateInput } from "@shopify/hydrogen/storefront-api-types";
 import type { FetcherWithComponents } from "react-router";
 import type { CartApiQueryFragment } from "storefront-api.generated";
+import { usePrefixPathWithLocale } from "~/hooks/use-prefix-path-with-locale";
 import type { CartLineOptimisticData } from "./cart-line-item";
 import { useCartFetcherSync } from "./store";
 
@@ -85,9 +86,11 @@ function UpdateCartButton({
   children: React.ReactNode;
   lines: CartLineUpdateInput[];
 }) {
+  const cartRoute = usePrefixPathWithLocale("/cart");
+
   return (
     <CartForm
-      route="/cart"
+      route={cartRoute}
       action={CartForm.ACTIONS.LinesUpdate}
       inputs={{ lines }}
     >

--- a/app/components/cart/cart-summary-actions.tsx
+++ b/app/components/cart/cart-summary-actions.tsx
@@ -6,6 +6,7 @@ import { useFetcher } from "react-router";
 import type { CartApiQueryFragment } from "storefront-api.generated";
 import { Banner } from "~/components/banner";
 import { Button } from "~/components/button";
+import { usePrefixPathWithLocale } from "~/hooks/use-prefix-path-with-locale";
 import { cn } from "~/utils/cn";
 import { useCartFetcherSync } from "./store";
 
@@ -14,6 +15,7 @@ export function NoteDialog({ cartNote: currentNote }: { cartNote: string }) {
   const [submitted, setSubmitted] = useState(false);
   const fetcher = useFetcher();
   useCartFetcherSync(fetcher);
+  const cartRoute = usePrefixPathWithLocale("/cart");
 
   useEffect(() => {
     if (fetcher.state === "idle" && fetcher.data) {
@@ -33,7 +35,7 @@ export function NoteDialog({ cartNote: currentNote }: { cartNote: string }) {
             inputs: { cartNote: formCartNote },
           }),
         },
-        { method: "POST", action: "/cart" },
+        { method: "POST", action: cartRoute },
       );
       setNote(formCartNote);
     }
@@ -115,6 +117,7 @@ export function DiscountDialog({
   const [code, setCode] = useState("");
   const fetcher = useFetcher();
   useCartFetcherSync(fetcher);
+  const cartRoute = usePrefixPathWithLocale("/cart");
   const submitted = Boolean(code && fetcher.state === "idle" && fetcher.data);
   const success = Boolean(
     submitted && discountCodes?.find((d) => d.code === code && d.applicable),
@@ -136,7 +139,7 @@ export function DiscountDialog({
             },
           }),
         },
-        { method: "POST", action: "/cart" },
+        { method: "POST", action: cartRoute },
       );
     }
   }
@@ -221,6 +224,7 @@ export function GiftCardDialog({
   const [code, setCode] = useState("");
   const fetcher = useFetcher();
   useCartFetcherSync(fetcher);
+  const cartRoute = usePrefixPathWithLocale("/cart");
   const submitted = Boolean(code && fetcher.state === "idle" && fetcher.data);
   const success = Boolean(
     submitted &&
@@ -244,7 +248,7 @@ export function GiftCardDialog({
             },
           }),
         },
-        { method: "POST", action: "/cart" },
+        { method: "POST", action: cartRoute },
       );
     }
   }

--- a/app/components/cart/cart-summary.tsx
+++ b/app/components/cart/cart-summary.tsx
@@ -8,16 +8,16 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { CartForm, Money, type OptimisticCart } from "@shopify/hydrogen";
 import { useThemeSettings } from "@weaverse/hydrogen";
 import clsx from "clsx";
-import { useEffect, useState } from "react";
-import { useFetcher } from "react-router";
+import { useState } from "react";
+import { useFetcher, useLocation } from "react-router";
 import type { CartApiQueryFragment } from "storefront-api.generated";
 import { Button } from "~/components/button";
 import { Link } from "~/components/link";
 import { Skeleton } from "~/components/skeleton";
 import { Spinner } from "~/components/spinner";
+import { usePrefixPathWithLocale } from "~/hooks/use-prefix-path-with-locale";
 import type { CartLayoutType } from "~/types/others";
 import type { ThemeSettings } from "~/types/weaverse";
-import { appendForwardedAttribution } from "~/utils/checkout-attribution";
 import { cn } from "~/utils/cn";
 import {
   DiscountDialog,
@@ -48,6 +48,10 @@ export function CartSummary({
   const [removingGiftCard, setRemovingGiftCard] = useState<string | null>(null);
   const dcRemoveFetcher = useFetcher({ key: "discount-code-remove" });
   const gcRemoveFetcher = useFetcher({ key: "gift-card-remove" });
+  const cartRoute = usePrefixPathWithLocale("/cart");
+  const checkoutRoute = usePrefixPathWithLocale("/cart/checkout");
+  const { search } = useLocation();
+  const checkoutHref = `${checkoutRoute}${search}`;
   // Line removal submits with this stable fetcherKey. The CartLineItem that
   // owns the trash button unmounts the moment the line is optimistically
   // spliced out, so its own fetcher response would be lost. Reading the keyed
@@ -65,26 +69,6 @@ export function CartSummary({
     appliedGiftCards,
     note,
   } = cart;
-
-  // Append ad-attribution params from the current storefront URL onto
-  // the checkout URL so Shopify's built-in tracking on the checkout
-  // subdomain sees consistent last-click identifiers (gclid, fbclid,
-  // utm_*, …). The initial render uses the unmodified checkoutUrl so
-  // SSR + client first-paint match; once the browser hydrates we swap
-  // in the enhanced URL via state. Server-side direct redirects (the
-  // Buy-now flow in app/routes/cart/lines.tsx) handle this server-side
-  // and don't go through this component.
-  const [enhancedCheckoutUrl, setEnhancedCheckoutUrl] = useState(checkoutUrl);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: recompute whenever the underlying checkoutUrl changes
-  useEffect(() => {
-    if (typeof window === "undefined" || !checkoutUrl) {
-      setEnhancedCheckoutUrl(checkoutUrl);
-      return;
-    }
-    setEnhancedCheckoutUrl(
-      appendForwardedAttribution(checkoutUrl, window.location.search),
-    );
-  }, [checkoutUrl]);
 
   // Show loading state for optimistic line item changes or pending cart actions
   const isCartUpdating =
@@ -123,7 +107,7 @@ export function CartSummary({
                   </span>
                 </div>
                 <CartForm
-                  route="/cart"
+                  route={cartRoute}
                   action={CartForm.ACTIONS.GiftCardCodesRemove}
                   inputs={{
                     giftCardCodes: [giftCard.id],
@@ -175,7 +159,7 @@ export function CartSummary({
                   <TagIcon className="h-4.5 w-4.5" aria-hidden="true" />
                   <span className="leading-normal">{discount.code}</span>
                   <CartForm
-                    route="/cart"
+                    route={cartRoute}
                     action={CartForm.ACTIONS.DiscountCodesUpdate}
                     inputs={{ discountCodes: updatedCodes || [] }}
                     fetcherKey="discount-code-remove"
@@ -271,7 +255,7 @@ export function CartSummary({
       )}
       {checkoutUrl && (
         <div className="mt-2 flex flex-col gap-3">
-          <a href={enhancedCheckoutUrl} target="_self">
+          <a href={checkoutHref} target="_self">
             <Button className="w-full">
               <span>{checkoutButtonText || "Continue to Checkout"}</span>
               {layout === "drawer" && (

--- a/app/components/layout/country-selector/use-country-selector.ts
+++ b/app/components/layout/country-selector/use-country-selector.ts
@@ -8,6 +8,7 @@ import {
   useRouteLoaderData,
   useSubmit,
 } from "react-router";
+import { usePrefixPathWithLocale } from "~/hooks/use-prefix-path-with-locale";
 import type { RootLoader } from "~/root";
 import type { I18nLocale, Localizations } from "~/types/others";
 import { DEFAULT_LOCALE } from "~/utils/const";
@@ -24,6 +25,7 @@ export function useCountrySelector() {
   const rootData = useRouteLoaderData<RootLoader>("root");
   const selectedLocale = rootData?.selectedLocale ?? DEFAULT_LOCALE;
   const { pathname, search } = useLocation();
+  const cartRoute = usePrefixPathWithLocale("/cart");
   const pathWithoutLocale = `${pathname.replace(
     selectedLocale.pathPrefix,
     "",
@@ -68,7 +70,7 @@ export function useCountrySelector() {
           inputs: { buyerIdentity },
         }),
       },
-      { method: "POST", action: "/cart" },
+      { method: "POST", action: cartRoute },
     );
   }
 

--- a/app/components/product/add-to-cart-button.tsx
+++ b/app/components/product/add-to-cart-button.tsx
@@ -15,6 +15,7 @@ import { useMatches } from "react-router";
 import { Button } from "~/components/button";
 import { useCartFetcherSync, useCartStore } from "~/components/cart/store";
 import { Spinner } from "~/components/spinner";
+import { usePrefixPathWithLocale } from "~/hooks/use-prefix-path-with-locale";
 import { cn } from "~/utils/cn";
 import { DEFAULT_LOCALE } from "~/utils/const";
 
@@ -33,9 +34,11 @@ export function AddToCartButton({
   analytics?: unknown;
   [key: string]: any;
 }) {
+  const cartRoute = usePrefixPathWithLocale("/cart");
+
   return (
     <CartForm
-      route="/cart"
+      route={cartRoute}
       inputs={{ lines }}
       action={CartForm.ACTIONS.LinesAdd}
     >

--- a/app/hooks/use-prefix-path-with-locale.ts
+++ b/app/hooks/use-prefix-path-with-locale.ts
@@ -1,19 +1,17 @@
 import { useLocation, useRouteLoaderData } from "react-router";
 import type { RootLoader } from "~/root";
-import { DEFAULT_LOCALE } from "~/utils/const";
+import { DEFAULT_LOCALE, getLocalePrefixFromPath } from "~/utils/const";
 
 export function usePrefixPathWithLocale(path: string) {
   const rootData = useRouteLoaderData<RootLoader>("root");
   const { pathname } = useLocation();
+  // Derive the prefix from the current URL first so cart forms post to the
+  // active locale's cart route. `||` (not `??`) lets the empty-string result
+  // for a non-locale path fall through to the loader's selected locale.
   const pathPrefix =
-    getPathPrefixFromPathname(pathname) ??
-    rootData?.selectedLocale?.pathPrefix ??
+    getLocalePrefixFromPath(pathname) ||
+    rootData?.selectedLocale?.pathPrefix ||
     DEFAULT_LOCALE.pathPrefix;
   const suffix = path.startsWith("/") ? path : `/${path}`;
   return pathPrefix + suffix;
-}
-
-function getPathPrefixFromPathname(pathname: string) {
-  const firstPathPart = `/${pathname.substring(1).split("/")[0].toLowerCase()}`;
-  return firstPathPart.length > 1 ? firstPathPart : "";
 }

--- a/app/hooks/use-prefix-path-with-locale.ts
+++ b/app/hooks/use-prefix-path-with-locale.ts
@@ -1,10 +1,19 @@
-import { useRouteLoaderData } from "react-router";
+import { useLocation, useRouteLoaderData } from "react-router";
 import type { RootLoader } from "~/root";
 import { DEFAULT_LOCALE } from "~/utils/const";
 
 export function usePrefixPathWithLocale(path: string) {
   const rootData = useRouteLoaderData<RootLoader>("root");
-  const { pathPrefix } = rootData?.selectedLocale ?? DEFAULT_LOCALE;
+  const { pathname } = useLocation();
+  const pathPrefix =
+    getPathPrefixFromPathname(pathname) ??
+    rootData?.selectedLocale?.pathPrefix ??
+    DEFAULT_LOCALE.pathPrefix;
   const suffix = path.startsWith("/") ? path : `/${path}`;
   return pathPrefix + suffix;
+}
+
+function getPathPrefixFromPathname(pathname: string) {
+  const firstPathPart = `/${pathname.substring(1).split("/")[0].toLowerCase()}`;
+  return firstPathPart.length > 1 ? firstPathPart : "";
 }

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -48,6 +48,7 @@ export default hydrogenRoutes([
     ]),
     ...prefix("cart", [
       index("routes/cart/cart-page.tsx"),
+      route("checkout", "routes/cart/checkout.tsx"),
       route(":lines", "routes/cart/lines.tsx"),
     ]),
     ...prefix("collections", [

--- a/app/routes/cart/cart-page.tsx
+++ b/app/routes/cart/cart-page.tsx
@@ -24,7 +24,7 @@ import { useCart } from "~/components/cart/store";
 import { ProductCard } from "~/components/product-card";
 import { Section } from "~/components/section";
 import { Swimlane } from "~/components/swimlane";
-import { COUNTRIES } from "~/utils/const";
+import { COUNTRIES, getLocalePrefixFromPath } from "~/utils/const";
 import { getFeaturedProducts } from "~/utils/featured-products";
 
 export async function action({ request, context }: ActionFunctionArgs) {
@@ -208,8 +208,8 @@ function getCountryCodeFromUrl(url: string | null) {
 
   try {
     const { pathname } = new URL(url);
-    const firstPathPart = `/${pathname.substring(1).split("/")[0].toLowerCase()}`;
-    return COUNTRIES[firstPathPart]?.country as CountryCode | undefined;
+    const prefix = getLocalePrefixFromPath(pathname);
+    return COUNTRIES[prefix]?.country as CountryCode | undefined;
   } catch {
     return;
   }

--- a/app/routes/cart/cart-page.tsx
+++ b/app/routes/cart/cart-page.tsx
@@ -7,6 +7,7 @@ import type {
   CartBuyerIdentityInput,
   CartLineInput,
   CartLineUpdateInput,
+  CountryCode,
 } from "@shopify/hydrogen/storefront-api-types";
 import { Suspense } from "react";
 import {
@@ -23,10 +24,11 @@ import { useCart } from "~/components/cart/store";
 import { ProductCard } from "~/components/product-card";
 import { Section } from "~/components/section";
 import { Swimlane } from "~/components/swimlane";
+import { COUNTRIES } from "~/utils/const";
 import { getFeaturedProducts } from "~/utils/featured-products";
 
 export async function action({ request, context }: ActionFunctionArgs) {
-  const { cart } = context;
+  const { cart, storefront } = context;
   const formData = await request.formData();
   const { action: cartFormAction, inputs } = CartForm.getFormInput(formData);
 
@@ -34,51 +36,89 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
   const status = 200;
   let result: CartQueryDataReturn;
+  const countryCode = getCountryCodeFromRequestOrReferer(
+    request,
+    storefront.i18n.country,
+  );
+  const localeBuyerIdentity: CartBuyerIdentityInput = {
+    countryCode,
+  };
+
+  async function syncCartBuyerIdentityToLocale() {
+    if (!cart.getCartId()) {
+      return;
+    }
+    const syncResult = await cart.updateBuyerIdentity(localeBuyerIdentity);
+    return syncResult?.cart?.id ? { cartId: syncResult.cart.id } : undefined;
+  }
 
   switch (cartFormAction) {
-    case CartForm.ACTIONS.LinesAdd:
-      result = await cart.addLines(inputs.lines as CartLineInput[]);
+    case CartForm.ACTIONS.LinesAdd: {
+      const lines = inputs.lines as CartLineInput[];
+      if (!cart.getCartId()) {
+        result = await cart.create({
+          lines,
+          buyerIdentity: localeBuyerIdentity,
+        });
+      } else {
+        const cartOptions = await syncCartBuyerIdentityToLocale();
+        result = await cart.addLines(lines, cartOptions);
+      }
       break;
-    case CartForm.ACTIONS.LinesUpdate:
-      result = await cart.updateLines(inputs.lines as CartLineUpdateInput[]);
+    }
+    case CartForm.ACTIONS.LinesUpdate: {
+      const cartOptions = await syncCartBuyerIdentityToLocale();
+      result = await cart.updateLines(
+        inputs.lines as CartLineUpdateInput[],
+        cartOptions,
+      );
       break;
-    case CartForm.ACTIONS.LinesRemove:
-      result = await cart.removeLines(inputs.lineIds as string[]);
+    }
+    case CartForm.ACTIONS.LinesRemove: {
+      const cartOptions = await syncCartBuyerIdentityToLocale();
+      result = await cart.removeLines(inputs.lineIds as string[], cartOptions);
       break;
+    }
     case CartForm.ACTIONS.NoteUpdate: {
+      const cartOptions = await syncCartBuyerIdentityToLocale();
       const cartNote = inputs.cartNote as string;
       if (cartNote) {
-        result = await cart.updateNote(cartNote);
+        result = await cart.updateNote(cartNote, cartOptions);
       }
       break;
     }
     case CartForm.ACTIONS.DiscountCodesUpdate: {
+      const cartOptions = await syncCartBuyerIdentityToLocale();
       const formDiscountCode = inputs.discountCode;
       const discountCodes = (
         formDiscountCode ? [formDiscountCode] : []
       ) as string[];
       discountCodes.push(...(inputs.discountCodes as string[]));
-      result = await cart.updateDiscountCodes(discountCodes);
+      result = await cart.updateDiscountCodes(discountCodes, cartOptions);
       break;
     }
     case CartForm.ACTIONS.GiftCardCodesAdd: {
+      const cartOptions = await syncCartBuyerIdentityToLocale();
       const giftCardCodes = (inputs.giftCardCodes as string[]) || [];
-      result = await cart.addGiftCardCodes(giftCardCodes);
+      result = await cart.addGiftCardCodes(giftCardCodes, cartOptions);
       break;
     }
     case CartForm.ACTIONS.GiftCardCodesUpdate: {
+      const cartOptions = await syncCartBuyerIdentityToLocale();
       // Backward compatibility: same as add gift card codes
       const giftCardCodes = (inputs.giftCardCodes as string[]) || [];
-      result = await cart.addGiftCardCodes(giftCardCodes);
+      result = await cart.addGiftCardCodes(giftCardCodes, cartOptions);
       break;
     }
     case CartForm.ACTIONS.GiftCardCodesRemove: {
+      const cartOptions = await syncCartBuyerIdentityToLocale();
       const giftCardIds = inputs.giftCardCodes as string[];
-      result = await cart.removeGiftCardCodes(giftCardIds);
+      result = await cart.removeGiftCardCodes(giftCardIds, cartOptions);
       break;
     }
     case CartForm.ACTIONS.BuyerIdentityUpdate:
       result = await cart.updateBuyerIdentity({
+        ...localeBuyerIdentity,
         ...(inputs.buyerIdentity as CartBuyerIdentityInput),
       });
       break;
@@ -148,6 +188,31 @@ export default function CartRoute() {
       </Suspense>
     </>
   );
+}
+
+function getCountryCodeFromRequestOrReferer(
+  request: Request,
+  fallbackCountryCode: CountryCode,
+) {
+  return (
+    getCountryCodeFromUrl(request.url) ??
+    getCountryCodeFromUrl(request.headers.get("Referer")) ??
+    fallbackCountryCode
+  );
+}
+
+function getCountryCodeFromUrl(url: string | null) {
+  if (!url) {
+    return;
+  }
+
+  try {
+    const { pathname } = new URL(url);
+    const firstPathPart = `/${pathname.substring(1).split("/")[0].toLowerCase()}`;
+    return COUNTRIES[firstPathPart]?.country as CountryCode | undefined;
+  } catch {
+    return;
+  }
 }
 
 function isLocalPath(url: string) {

--- a/app/routes/cart/checkout.tsx
+++ b/app/routes/cart/checkout.tsx
@@ -2,6 +2,7 @@ import type { CartBuyerIdentityInput } from "@shopify/hydrogen/storefront-api-ty
 import type { LoaderFunctionArgs } from "react-router";
 import { redirect } from "react-router";
 import { appendForwardedAttribution } from "~/utils/checkout-attribution";
+import { getLocalePrefixFromPath } from "~/utils/const";
 
 export async function loader({ context, request }: LoaderFunctionArgs) {
   const { cart, storefront } = context;
@@ -14,7 +15,10 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     result?.cart?.checkoutUrl ?? (await cart.get())?.checkoutUrl;
 
   if (!checkoutUrl) {
-    return redirect("/cart");
+    // Keep the buyer on their active locale's cart instead of dropping them
+    // onto the default-locale cart.
+    const localePrefix = getLocalePrefixFromPath(requestUrl.pathname);
+    return redirect(`${localePrefix}/cart`);
   }
 
   const headers = result?.cart?.id ? cart.setCartId(result.cart.id) : undefined;

--- a/app/routes/cart/checkout.tsx
+++ b/app/routes/cart/checkout.tsx
@@ -1,0 +1,27 @@
+import type { CartBuyerIdentityInput } from "@shopify/hydrogen/storefront-api-types";
+import type { LoaderFunctionArgs } from "react-router";
+import { redirect } from "react-router";
+import { appendForwardedAttribution } from "~/utils/checkout-attribution";
+
+export async function loader({ context, request }: LoaderFunctionArgs) {
+  const { cart, storefront } = context;
+  const requestUrl = new URL(request.url);
+  const result = await cart.updateBuyerIdentity({
+    countryCode: storefront.i18n.country,
+  } as CartBuyerIdentityInput);
+
+  const checkoutUrl =
+    result?.cart?.checkoutUrl ?? (await cart.get())?.checkoutUrl;
+
+  if (!checkoutUrl) {
+    return redirect("/cart");
+  }
+
+  const headers = result?.cart?.id ? cart.setCartId(result.cart.id) : undefined;
+  const attributedCheckoutUrl = appendForwardedAttribution(
+    checkoutUrl,
+    requestUrl.search,
+  );
+
+  return redirect(attributedCheckoutUrl, { headers });
+}

--- a/app/utils/const.ts
+++ b/app/utils/const.ts
@@ -176,6 +176,17 @@ export const DEFAULT_LOCALE: I18nLocale = Object.freeze({
   pathPrefix: "",
 });
 
+/**
+ * Extract the locale path prefix (e.g. `/en-ca`) from a pathname's first
+ * segment, validated against the known `COUNTRIES` map. Returns `""` for the
+ * default locale or any non-locale path (e.g. `/products/...`) so a regular
+ * page segment is never mistaken for a locale prefix.
+ */
+export function getLocalePrefixFromPath(pathname: string): string {
+  const firstPathPart = `/${pathname.substring(1).split("/")[0].toLowerCase()}`;
+  return COUNTRIES[firstPathPart] ? firstPathPart : "";
+}
+
 export const FILTER_URL_PREFIX = "filter.";
 
 export const LANGUAGE_LABELS: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Route all cart mutations through the locale-prefixed cart path.
- Create or sync cart buyer identity from the active locale before cart mutations.
- Add a local checkout route that refreshes buyer identity before redirecting to Shopify checkout.
- Preserve checkout attribution params when using the local checkout handoff.

## Why

TheOutnet exposed a reusable Hydrogen starter-theme issue: localized PDP pricing can show the selected market currency, but cart and checkout can fall back to the default currency when cart mutations post to `/cart` instead of the locale route.

## Verification

- `npx biome check app/hooks/use-prefix-path-with-locale.ts app/components/product/add-to-cart-button.tsx app/components/cart/cart-line-item.tsx app/components/cart/cart-line-qty-adjust.tsx app/components/cart/cart-summary.tsx app/components/cart/cart-summary-actions.tsx app/components/layout/country-selector/use-country-selector.ts app/routes/cart/cart-page.tsx app/routes/cart/checkout.tsx app/routes.ts --write`
- `npm run typecheck`
- `npm run build`

## Notes

- Fresh clone `npm install` surfaced existing dependency audit debt: 20 vulnerabilities.
- This PR does not add new runtime dependencies.
