### PR TITLE
perf: client-side cart bootstrap + Oxygen full-page cache for anonymous documents

### DIFF
--- a/app/.server/root.ts
+++ b/app/.server/root.ts
@@ -51,14 +51,15 @@ export async function loadCriticalData({
  * Load data for rendering content below the fold. This data is deferred and will be
  * fetched after the initial page load. If it's unavailable, the page should still 200.
  * Make sure to not throw any errors here, as it will cause the page to 500.
+ *
+ * NOTE: keep this loader free of personalized data (cart, customer tokens).
+ * Deferred values stream into the HTML document, and the document must stay
+ * anonymous for Oxygen's full-page cache (see entry.server.tsx). Personalized
+ * state is bootstrapped client-side via /api/cart in CartStoreSync.
  */
-export function loadDeferredData({ context }: LoaderFunctionArgs) {
-  const { cart, customerAccount } = context;
-
+export function loadDeferredData(args: LoaderFunctionArgs) {
   return {
-    cart: cart.get(),
-    swatchesConfigs: getSwatchesConfigs(context),
-    customerAccessToken: customerAccount.getAccessToken(),
+    swatchesConfigs: getSwatchesConfigs(args.context),
   };
 }
 

--- a/app/components/cart/store.ts
+++ b/app/components/cart/store.ts
@@ -1,14 +1,20 @@
 import { CartForm } from "@shopify/hydrogen";
 import { useEffect, useRef } from "react";
 import type { Fetcher } from "react-router";
-import { useFetchers, useRouteLoaderData } from "react-router";
+import { useFetcher, useFetchers } from "react-router";
 import type { CartApiQueryFragment } from "storefront-api.generated";
 import { create } from "zustand";
-import type { RootLoader } from "~/root";
+import type { loader as apiCartLoader } from "~/routes/api/cart";
 
 type CartStore = {
   isOpen: boolean;
   serverCart: CartApiQueryFragment | null;
+  /**
+   * Customer Account API access token for the Shopify account web component.
+   * Bootstrapped client-side via /api/cart — it must never be embedded in
+   * the SSR document (see entry.server.tsx full-page cache notes).
+   */
+  customerAccessToken: string | null;
   open: () => void;
   close: () => void;
   toggle: (open?: boolean) => void;
@@ -17,6 +23,7 @@ type CartStore = {
 export const useCartStore = create<CartStore>()((set) => ({
   isOpen: false,
   serverCart: null,
+  customerAccessToken: null,
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false }),
   toggle: (open) =>
@@ -275,39 +282,45 @@ export function useCart(): CartWithOptimistic | null {
 }
 
 /**
- * Syncs cart data from root loader's deferred promise into zustand.
- * Uses `updatedAt` to skip stale root loader data when a fetcher
- * already synced fresher post-mutation cart state.
+ * Bootstraps personalized state (cart + customer access token) client-side
+ * from /api/cart after hydration.
  *
+ * This data used to come from the root loader's deferred promise, but
+ * deferred values stream into the SSR document — personalizing every page
+ * and blocking Oxygen's full-page cache (see entry.server.tsx). Fetching
+ * after hydration keeps the document anonymous.
+ *
+ * Post-mutation freshness is handled by `useCartFetcherSync`; the
+ * `updatedAt` guard below only protects against this bootstrap racing a
+ * faster mutation fetcher.
  */
 export function CartStoreSync() {
-  const rootData = useRouteLoaderData<RootLoader>("root");
-  const promiseRef = useRef<unknown>(null);
-  const cartPromise = rootData?.cart;
-
+  const fetcher = useFetcher<typeof apiCartLoader>();
+  const load = fetcher.load;
   useEffect(() => {
-    if (cartPromise && cartPromise !== promiseRef.current) {
-      promiseRef.current = cartPromise;
-      Promise.resolve(cartPromise)
-        .then((resolved) => {
-          if (!resolved) {
-            useCartStore.setState({ serverCart: null });
-            return;
-          }
-          const current = useCartStore.getState().serverCart;
-          const resolvedTime = new Date(resolved.updatedAt).getTime();
-          const currentTime = current?.updatedAt
-            ? new Date(current.updatedAt).getTime()
-            : 0;
-          if (resolvedTime >= currentTime) {
-            useCartStore.setState({ serverCart: resolved });
-          }
-        })
-        .catch(() => {
-          // Cart fetch failed — leave current state as-is
-        });
+    load("/api/cart");
+  }, [load]);
+  const payload = fetcher.data;
+  useEffect(() => {
+    if (!payload) {
+      return;
     }
-  }, [cartPromise]);
-
+    useCartStore.setState({
+      customerAccessToken: payload.customerAccessToken,
+    });
+    const resolved = payload.cart;
+    if (!resolved) {
+      useCartStore.setState({ serverCart: null });
+      return;
+    }
+    const current = useCartStore.getState().serverCart;
+    const resolvedTime = new Date(resolved.updatedAt).getTime();
+    const currentTime = current?.updatedAt
+      ? new Date(current.updatedAt).getTime()
+      : 0;
+    if (resolvedTime >= currentTime) {
+      useCartStore.setState({ serverCart: resolved as CartApiQueryFragment });
+    }
+  }, [payload]);
   return null;
 }

--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -1,15 +1,10 @@
 import { MagnifyingGlassIcon, UserIcon } from "@phosphor-icons/react";
 import { useThemeSettings } from "@weaverse/hydrogen";
 import { cva } from "class-variance-authority";
-import { Suspense } from "react";
-import {
-  Await,
-  useLocation,
-  useRouteError,
-  useRouteLoaderData,
-} from "react-router";
+import { useLocation, useRouteError, useRouteLoaderData } from "react-router";
 import useWindowScroll from "react-use/esm/useWindowScroll";
 import { CartDrawer } from "~/components/cart/cart-drawer";
+import { useCartStore } from "~/components/cart/store";
 import Link from "~/components/link";
 import type { RootLoader } from "~/root";
 import type { ThemeSettings } from "~/types/weaverse";
@@ -128,27 +123,22 @@ function ShopifyAccountButton() {
   let rootData = useRouteLoaderData<RootLoader>("root");
   let publicStoreDomain = rootData?.publicStoreDomain;
   let publicAccessToken = rootData?.consent?.storefrontAccessToken;
-
+  // Bootstrapped client-side via /api/cart (CartStoreSync) — the token must
+  // not be embedded in the SSR document, which stays anonymous so Oxygen
+  // can full-page cache it. Until it loads, the component renders the
+  // signed-out avatar — same as the previous Suspense fallback.
+  let customerAccessToken = useCartStore((state) => state.customerAccessToken);
   return (
-    <Suspense fallback={<UserIcon className="h-5 w-5" />}>
-      <Await
-        resolve={rootData?.customerAccessToken}
-        errorElement={<UserIcon className="h-5 w-5" />}
-      >
-        {(customerAccessToken) => (
-          <shopify-store
-            store-domain={publicStoreDomain}
-            public-access-token={publicAccessToken}
-            customer-access-token={customerAccessToken || undefined}
-          >
-            <shopify-account sign-in-url="/account/login">
-              <span slot="signed-out-avatar">
-                <UserIcon className="h-5 w-5" />
-              </span>
-            </shopify-account>
-          </shopify-store>
-        )}
-      </Await>
-    </Suspense>
+    <shopify-store
+      store-domain={publicStoreDomain}
+      public-access-token={publicAccessToken}
+      customer-access-token={customerAccessToken || undefined}
+    >
+      <shopify-account sign-in-url="/account/login">
+        <span slot="signed-out-avatar">
+          <UserIcon className="h-5 w-5" />
+        </span>
+      </shopify-account>
+    </shopify-store>
   );
 }

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -6,7 +6,7 @@ import { isbot } from "isbot";
 import { renderToReadableStream } from "react-dom/server";
 import type { EntryContext } from "react-router";
 import { ServerRouter } from "react-router";
-
+import { getFullPageCacheControl } from "~/utils/full-page-cache";
 import { getWeaverseCsp } from "~/weaverse/csp";
 
 export default async function handleRequest(
@@ -53,6 +53,20 @@ export default async function handleRequest(
   responseHeaders.set("Content-Type", "text/html");
   // TODO: change to Content-Security-Policy when you ready with your CSP configs.
   responseHeaders.set("Content-Security-Policy-Report-Only", header);
+  // Opt anonymous document responses into Oxygen's full-page cache. Both
+  // headers are required by Oxygen; responses that commit a session cookie
+  // (Set-Cookie in server.ts) are excluded by Oxygen automatically. See
+  // app/utils/full-page-cache.ts for the gating rules.
+  const fullPageCacheControl = getFullPageCacheControl(
+    request,
+    responseStatusCode,
+  );
+  if (fullPageCacheControl) {
+    responseHeaders.set("Oxygen-Cache-Control", fullPageCacheControl);
+    if (!responseHeaders.has("Vary")) {
+      responseHeaders.set("Vary", "Accept-Encoding");
+    }
+  }
 
   return new Response(body, {
     headers: responseHeaders,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,7 +1,7 @@
 import "@fontsource-variable/cabin"; // Supports weights 400-700
 import "@fontsource-variable/newsreader"; // Supports weights 200-900
 import { TooltipProvider } from "@radix-ui/react-tooltip";
-import type { SeoConfig } from "@shopify/hydrogen";
+import type { CartReturn, SeoConfig } from "@shopify/hydrogen";
 import { Analytics, getSeoMeta, useNonce } from "@shopify/hydrogen";
 import { useThemeSettings, withWeaverse } from "@weaverse/hydrogen";
 import type { CSSProperties } from "react";
@@ -19,7 +19,7 @@ import {
 } from "react-router";
 import type { ThemeSettings } from "~/types/weaverse";
 import { loadCriticalData, loadDeferredData } from "./.server/root";
-import { CartStoreSync } from "./components/cart/store";
+import { CartStoreSync, useCartStore } from "./components/cart/store";
 import { Footer } from "./components/layout/footer";
 import { Header } from "./components/layout/header";
 import { ScrollingAnnouncement } from "./components/layout/scrolling-announcement";
@@ -110,6 +110,10 @@ export const Layout = withWeaverse(function RootLayout({
   const locale = data?.selectedLocale ?? DEFAULT_LOCALE;
   const { topbarHeight, topbarText } = useThemeSettings<ThemeSettings>();
   const shouldShowNewsletterPopup = useShouldRenderNewsletterPopup();
+  // Cart is bootstrapped client-side (see CartStoreSync) so the SSR document
+  // stays anonymous and Oxygen can full-page cache it. The provider re-renders
+  // as the store updates, so cart_updated analytics still fire on mutations.
+  const serverCart = useCartStore((state) => state.serverCart);
 
   // Bypass Weaverse theme layout for Hydrogen dev tools
   // See: https://github.com/Weaverse/pilot/issues/321
@@ -197,7 +201,10 @@ export const Layout = withWeaverse(function RootLayout({
       >
         {data ? (
           <Analytics.Provider
-            cart={data.cart}
+            // CartApiQueryFragment is the same runtime shape cart.get()
+            // returned before (pilot's custom cart fragment) — the nominal
+            // CartReturn type just demands `metafields` we never query.
+            cart={serverCart as unknown as CartReturn}
             shop={data.shop}
             consent={data.consent}
           >

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -24,6 +24,7 @@ export default hydrogenRoutes([
     route("pages/:pageHandle", "routes/pages/regular-page.tsx"),
     route("discount/:code", "routes/others/discount-code.tsx"),
     ...prefix("api", [
+      route("cart", "routes/api/cart.ts"),
       route("countries", "routes/api/countries.ts"),
       route("customer", "routes/api/customer.ts"),
       route("featured-products", "routes/api/featured-products.ts"),

--- a/app/routes/api/cart.ts
+++ b/app/routes/api/cart.ts
@@ -1,0 +1,27 @@
+import type { LoaderFunctionArgs } from "react-router";
+import { data } from "react-router";
+
+/**
+ * Client-side cart/session bootstrap.
+ *
+ * The cart and the customer access token used to live in the root loader's
+ * deferred data, which streams into the rendered HTML document. That made
+ * every document response personalized, blocking Oxygen's full-page cache
+ * (and risking one visitor's cart leaking into another's cached page).
+ * `CartStoreSync` now fetches this endpoint after hydration instead.
+ *
+ * `no-store`: this response IS personalized — it must never enter any
+ * shared cache.
+ */
+export async function loader({ context }: LoaderFunctionArgs) {
+  const { cart, customerAccount } = context;
+  const [cartData, customerAccessToken] = await Promise.all([
+    cart.get(),
+    customerAccount.getAccessToken().catch(() => null),
+  ]);
+
+  return data(
+    { cart: cartData, customerAccessToken: customerAccessToken ?? null },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/app/utils/full-page-cache.ts
+++ b/app/utils/full-page-cache.ts
@@ -1,0 +1,76 @@
+// First path segment may be a locale prefix (e.g. /fr-fr/account).
+const LOCALE_SEGMENT_RE = /^[a-z]{2}(?:-[a-z]{2})?$/i;
+
+// Never full-page cache: personalized or mutating surfaces, plus dev tools.
+const UNCACHEABLE_SEGMENTS = new Set([
+  "account",
+  "api",
+  "cart",
+  "discount",
+  "graphiql",
+  "subrequest-profiler",
+]);
+
+// Presence of any of these means the request comes from Weaverse Studio
+// (design mode / revision preview) — it must always reach the worker.
+const WEAVERSE_PREVIEW_PARAMS = [
+  "__revisionId",
+  "isDesignMode",
+  "weaverseHost",
+  "weaverseProjectId",
+  "weaverseVersion",
+];
+
+/**
+ * Decide whether this document response may enter Oxygen's full-page cache.
+ *
+ * Per https://shopify.dev/docs/storefronts/headless/hydrogen/caching/full-page-cache
+ * a response is cacheable only with `Oxygen-Cache-Control: public` (non-zero
+ * max-age) AND a `Vary` header AND no `Set-Cookie`. The Set-Cookie guard is
+ * enforced by Oxygen itself (session commits in server.ts automatically keep
+ * those responses out of the cache), so this gate only needs to exclude:
+ *
+ * - non-GET / non-200 responses
+ * - personalized or mutating routes (account, cart, discount, api)
+ * - Weaverse Studio design-mode and revision-preview requests
+ *
+ * The document itself is safe to share because all personalized state
+ * (cart, customer access token) is bootstrapped client-side via /api/cart —
+ * see CartStoreSync. Do not reintroduce personalized data into root/route
+ * loaders without revisiting this.
+ *
+ * Freshness: 60s shared max-age bounds publish-to-live latency (Oxygen's
+ * full-page cache cannot be purged without a redeploy), while the 1-day
+ * stale-while-revalidate keeps responses instant during background refresh.
+ */
+export function getFullPageCacheControl(
+  request: Request,
+  responseStatusCode: number,
+): string | null {
+  if (request.method !== "GET" || responseStatusCode !== 200) {
+    return null;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(request.url);
+  } catch {
+    return null;
+  }
+
+  for (const param of WEAVERSE_PREVIEW_PARAMS) {
+    if (url.searchParams.has(param)) {
+      return null;
+    }
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  const first = segments[0]?.toLowerCase() ?? "";
+  const second = segments[1]?.toLowerCase() ?? "";
+  const routeSegment = LOCALE_SEGMENT_RE.test(first) ? second : first;
+  if (UNCACHEABLE_SEGMENTS.has(routeSegment)) {
+    return null;
+  }
+
+  return "public, max-age=60, stale-while-revalidate=86400";
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@shopify/hydrogen": "^2026.4.2",
         "@shopify/hydrogen-react": "^2026.4.2",
         "@tailwindcss/vite": "^4.3.0",
-        "@weaverse/hydrogen": "^5.13.0",
+        "@weaverse/hydrogen": "^5.15.0",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "colord": "2.9.3",
@@ -5505,24 +5505,24 @@
       "license": "MIT"
     },
     "node_modules/@weaverse/core": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@weaverse/core/-/core-5.13.0.tgz",
-      "integrity": "sha512-gKCvC/pCkP7Z3sFw7m5PnRshg0/j0oHJe5jEQQhCqAE66odjwgTy7DAc8/Rx7bjcBaZlw3JA38RwNq/evCLXrQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@weaverse/core/-/core-5.15.0.tgz",
+      "integrity": "sha512-aheNmaal/ljEY8CLqMMXjBZAhikjEns8+/69uPcnepqgDObL/wN2XQG1Nb1ZI5GPiHaUolU6lZubgfjuOPARRA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@weaverse/hydrogen": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@weaverse/hydrogen/-/hydrogen-5.13.0.tgz",
-      "integrity": "sha512-IS0w2Yi4868KuOt126dYsp3KoaUYsvstPa2r+ubRWxasiF3kdsFAdJBmI++8fJdo7QT9PeQ90vXAximXGAeabg==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@weaverse/hydrogen/-/hydrogen-5.15.0.tgz",
+      "integrity": "sha512-Cb/9S7fXgR8c9Yj3ObI+ASKW1ACno9m7gY5mHkcYGQJeqqSCykQ9TNvLkoGUw/KQCGSERqqM7ONbltm7rTGPxQ==",
       "license": "MIT",
       "dependencies": {
         "@shopify/hydrogen": ">=2025.5",
         "@shopify/remix-oxygen": "3",
-        "@weaverse/react": "5.13.0",
-        "@weaverse/schema": "0.8.2",
+        "@weaverse/react": "5.15.0",
+        "@weaverse/schema": "0.9.0",
         "react": ">=19",
         "react-dom": ">=19",
         "react-error-boundary": "^6",
@@ -5533,12 +5533,12 @@
       }
     },
     "node_modules/@weaverse/react": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@weaverse/react/-/react-5.13.0.tgz",
-      "integrity": "sha512-KcyjatWURPo0Us061btlmXD0S1ZxC8Z0tsTgFyp8uF0ZxyqbSYhZlnEGBCxQNwtEJGXm1ujGLx41AEAjHcYC1w==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@weaverse/react/-/react-5.15.0.tgz",
+      "integrity": "sha512-dWbFk3d2MnTzXNDUcAgyPDNh9Mbmzt4CtNymMrKZwqQmVGozbwvMF9YQ30MPcXpj4ZeovNhaevfn/tOMWHJNWw==",
       "license": "MIT",
       "dependencies": {
-        "@weaverse/core": "5.13.0",
+        "@weaverse/core": "5.15.0",
         "clsx": "^2.1.1",
         "react": ">=19",
         "react-dom": ">=19"
@@ -5548,9 +5548,9 @@
       }
     },
     "node_modules/@weaverse/schema": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@weaverse/schema/-/schema-0.8.2.tgz",
-      "integrity": "sha512-haD/+xU+Da6XiNoFcSEushMwBv+TaZD0qZHmOI/IABfbnu+b0jzDBunni6RDyiUnHyazkKk/MKY5KNP/AH+mEQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@weaverse/schema/-/schema-0.9.0.tgz",
+      "integrity": "sha512-ReK7mSO+XoWS0VQ4XnEkWGMFppjb/jvU03UAvndJ5vvJduOiSNBdM7pYPy3/B0XVEqJWJvS8S3+rqNPAzWiJbw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@shopify/hydrogen": "^2026.4.2",
     "@shopify/hydrogen-react": "^2026.4.2",
     "@tailwindcss/vite": "^4.3.0",
-    "@weaverse/hydrogen": "^5.13.0",
+    "@weaverse/hydrogen": "^5.15.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "colord": "2.9.3",


### PR DESCRIPTION
Items 3+5 from the [Weaverse/builder#2450 investigation](https://github.com/Weaverse/builder/issues/2450#issuecomment-4668232032).

## Why the homepage was `oxygen-full-page-cache: uncacheable`

Per the [Oxygen full-page cache docs](https://shopify.dev/docs/storefronts/headless/hydrogen/caching/full-page-cache), a cacheable response needs `Oxygen-Cache-Control: public` (non-zero max-age) **and** a `Vary` header **and** no `Set-Cookie`. Pilot set neither header — and couldn't safely, because the root loader's deferred data streamed `cart.get()` and `customerAccount.getAccessToken()` into every document: caching that HTML would serve one visitor's cart/token to another.

## Changes

1. **`GET /api/cart`** (new): returns `{ cart, customerAccessToken }` with `Cache-Control: no-store`. Personalized data now travels on this endpoint only.
2. **`CartStoreSync`** bootstraps the zustand store from `/api/cart` after hydration instead of the root deferred promise. Post-mutation freshness is unchanged (`useCartFetcherSync`); the `updatedAt` guard still protects against the bootstrap racing a faster mutation fetcher.
3. **Header account button** reads the token from the store — same signed-out avatar until it loads as the previous `Suspense` fallback showed.
4. **`Analytics.Provider`** receives the live store cart, so `cart_updated`/add/remove events keep firing as mutations sync.
5. **`entry.server.tsx`** sets `Oxygen-Cache-Control: public, max-age=60, stale-while-revalidate=86400` + `Vary: Accept-Encoding` on anonymous GET 200 documents. The gate (`app/utils/full-page-cache.ts`) excludes `account`/`cart`/`discount`/`api`/dev-tool routes (locale-prefix aware) and any request carrying Weaverse design-mode / revision-preview params. Responses that commit a session cookie are excluded by Oxygen itself (`Set-Cookie` rule).
6. **`@weaverse/hydrogen` → `^5.15.0`** (multi-instance Studio handshake fixes, live-theme revalidation instance reuse); `package-lock.json` regenerated with `npm i --package-lock-only --workspaces=false`.

## Tradeoffs, stated

- **Publish-to-live latency for cached documents:** up to 60s (`max-age=60`) — Oxygen's full-page cache cannot be purged without a redeploy, so the fresh window is kept deliberately short; SWR keeps responses instant during background refresh.
- **CSP nonce** is frozen for a cached document's lifetime (header + HTML cached together, so nothing breaks; marginally weakens nonce-based CSP).
- First paint of cart badge/account state now arrives with the `/api/cart` response instead of the SSR stream — same pattern as Shopify's [client-side cart recipe](https://shopify.dev/docs/storefronts/headless/hydrogen/cart/render-client-side).

## Verification

`tsc --noEmit` clean, biome clean, full `shopify hydrogen build --codegen` green (client + SSR). After deploy, `curl -sI https://pilot.weaverse.dev/` should show `oxygen-full-page-cache: miss → hit` on consecutive anonymous requests; `/account` and design-mode URLs must stay `uncacheable`.