### PR TITLE
chore: bump @weaverse/hydrogen to 5.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@shopify/hydrogen": "^2026.4.2",
         "@shopify/hydrogen-react": "^2026.4.2",
         "@tailwindcss/vite": "^4.3.0",
-        "@weaverse/hydrogen": "^5.15.0",
+        "@weaverse/hydrogen": "^5.15.1",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "colord": "2.9.3",
@@ -5505,23 +5505,23 @@
       "license": "MIT"
     },
     "node_modules/@weaverse/core": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@weaverse/core/-/core-5.15.0.tgz",
-      "integrity": "sha512-aheNmaal/ljEY8CLqMMXjBZAhikjEns8+/69uPcnepqgDObL/wN2XQG1Nb1ZI5GPiHaUolU6lZubgfjuOPARRA==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@weaverse/core/-/core-5.15.1.tgz",
+      "integrity": "sha512-kmAuhjwLBAz5mVVoFBDrRrEdMaHyTk5WiBo5eRM+6fWBR+X3+2+lAITHbaezkp7QaFgnmMjeksAVLMISY2ABnA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@weaverse/hydrogen": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@weaverse/hydrogen/-/hydrogen-5.15.0.tgz",
-      "integrity": "sha512-Cb/9S7fXgR8c9Yj3ObI+ASKW1ACno9m7gY5mHkcYGQJeqqSCykQ9TNvLkoGUw/KQCGSERqqM7ONbltm7rTGPxQ==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@weaverse/hydrogen/-/hydrogen-5.15.1.tgz",
+      "integrity": "sha512-uLUQPaUx5tTJVvIo8Ia0vCMOSoacWhqW7PoV4CM9+Lpx3NcGLQKUCn8mPSyOgTaikFtuXrjh+lwxX3eoyTNhJg==",
       "license": "MIT",
       "dependencies": {
         "@shopify/hydrogen": ">=2025.5",
         "@shopify/remix-oxygen": "3",
-        "@weaverse/react": "5.15.0",
+        "@weaverse/react": "5.15.1",
         "@weaverse/schema": "0.9.0",
         "react": ">=19",
         "react-dom": ">=19",
@@ -5533,12 +5533,12 @@
       }
     },
     "node_modules/@weaverse/react": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@weaverse/react/-/react-5.15.0.tgz",
-      "integrity": "sha512-dWbFk3d2MnTzXNDUcAgyPDNh9Mbmzt4CtNymMrKZwqQmVGozbwvMF9YQ30MPcXpj4ZeovNhaevfn/tOMWHJNWw==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@weaverse/react/-/react-5.15.1.tgz",
+      "integrity": "sha512-wD+a+UZhSULrrEex0N6Ydi7euqGNdRxHpiZEPXRmItnouNf6l+TpKjUKJteyuZhohHO6I/QM6Tgpn9TDmL3pAQ==",
       "license": "MIT",
       "dependencies": {
-        "@weaverse/core": "5.15.0",
+        "@weaverse/core": "5.15.1",
         "clsx": "^2.1.1",
         "react": ">=19",
         "react-dom": ">=19"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@shopify/hydrogen": "^2026.4.2",
     "@shopify/hydrogen-react": "^2026.4.2",
     "@tailwindcss/vite": "^4.3.0",
-    "@weaverse/hydrogen": "^5.15.0",
+    "@weaverse/hydrogen": "^5.15.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "colord": "2.9.3",


### PR DESCRIPTION
SDK patch release: loadPage URL normalization — utm_*/fbclid/gclid no longer fragment the Oxygen subrequest cache key for Builder page requests (Weaverse/weaverse#458). Lock regenerated with `npm i --package-lock-only --workspaces=false`.