### PR TITLE
perf: cut SSR bundle 3.5MB -> 1.4MB; raise FPC freshness to 300s

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -26,7 +26,10 @@ export async function loader(args: LoaderFunctionArgs) {
   // Load async data in parallel for better performance
   const [weaverseData, { shop }] = await Promise.all([
     context.weaverse.loadPage({ type }),
-    context.storefront.query<ShopQuery>(SHOP_QUERY),
+    // Shop name/description only — effectively static content.
+    context.storefront.query<ShopQuery>(SHOP_QUERY, {
+      cache: context.storefront.CacheLong(),
+    }),
   ]);
 
   // Check weaverseData after parallel loading

--- a/app/utils/full-page-cache.ts
+++ b/app/utils/full-page-cache.ts
@@ -39,7 +39,8 @@ const WEAVERSE_PREVIEW_PARAMS = [
  * see CartStoreSync. Do not reintroduce personalized data into root/route
  * loaders without revisiting this.
  *
- * Freshness: 60s shared max-age bounds publish-to-live latency (Oxygen's
+ * Freshness: 300s shared max-age (matching the Weaverse SDK's Builder-data
+ * freshness — total worst-case publish-to-live is ~10 minutes; Oxygen's
  * full-page cache cannot be purged without a redeploy), while the 1-day
  * stale-while-revalidate keeps responses instant during background refresh.
  */
@@ -72,5 +73,5 @@ export function getFullPageCacheControl(
     return null;
   }
 
-  return "public, max-age=60, stale-while-revalidate=86400";
+  return "public, max-age=300, stale-while-revalidate=86400";
 }

--- a/app/utils/ssr-client-only-stub.ts
+++ b/app/utils/ssr-client-only-stub.ts
@@ -1,0 +1,17 @@
+/**
+ * SSR replacement for client-only heavy modules (see vite.config.ts).
+ *
+ * The Oxygen worker is a single file, so Rollup inlines every dynamic
+ * import — `React.lazy` keeps a module off the critical path at runtime
+ * but NOT out of the server bundle. react-player v3 alone drags in
+ * hls.js, dashjs, media-chrome and the Mux/Vimeo players (~3MB of
+ * source), all of which can only ever run in a browser; that parse/
+ * compile cost is paid on every cold start.
+ *
+ * Safe because the player renders only behind `useInView` (hero-video),
+ * which is always false during SSR — this stub is never actually
+ * rendered on the server, it only satisfies the import.
+ */
+export default function ClientOnlyStub(): null {
+  return null;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,37 @@ import { reactRouter } from "@react-router/dev/vite";
 import { hydrogen } from "@shopify/hydrogen/vite";
 import { oxygen } from "@shopify/mini-oxygen/vite";
 import tailwindcss from "@tailwindcss/vite";
+import { fileURLToPath } from "node:url";
+import type { Plugin } from "vite";
 import { defineConfig } from "vite";
-
+// Client-only heavy modules replaced with a stub in the SSR build. The
+// worker bundle inlines all dynamic imports, so React.lazy alone cannot
+// keep them out of the server file — react-player's media stack (hls.js,
+// dashjs, media-chrome, Mux/Vimeo) is ~3MB of cold-start parse cost that
+// can only ever run in a browser. See app/utils/ssr-client-only-stub.ts.
+const SSR_STUBBED_MODULES = new Set(["react-player"]);
+function ssrStubClientOnlyModules(): Plugin {
+  return {
+    name: "ssr-stub-client-only-modules",
+    enforce: "pre",
+    resolveId(id, _importer, options) {
+      if (options?.ssr && SSR_STUBBED_MODULES.has(id)) {
+        return fileURLToPath(
+          new URL("./app/utils/ssr-client-only-stub.ts", import.meta.url),
+        );
+      }
+      return null;
+    },
+  };
+}
 export default defineConfig(({ isSsrBuild }) => ({
-  plugins: [hydrogen(), oxygen(), reactRouter(), tailwindcss()],
+  plugins: [
+    hydrogen(),
+    oxygen(),
+    reactRouter(),
+    tailwindcss(),
+    ssrStubClientOnlyModules(),
+  ],
   resolve: {
     tsconfigPaths: true,
   },


### PR DESCRIPTION
The Oxygen worker is a single file, so Rollup inlines every dynamic
import — React.lazy never kept react-player's media stack (hls.js,
dashjs, media-chrome, Mux/Vimeo players: ~3.1MB of source) out of the
server bundle, and that parse/compile cost was paid on every cold
start. A resolveId plugin now substitutes a stub for react-player in
the SSR build only; safe because the player renders behind useInView,
which is always false during SSR. Browsers still get the real player
(client vendor-media chunk unchanged).

Also: SHOP_QUERY -> CacheLong (shop name/description is static), and
full-page cache max-age 60->300 to match the SDK's Builder-data
freshness window — worst-case publish-to-live becomes ~10min, hit
ratio on low-traffic POPs roughly 5x.
