### PR TITLE
chore: bump @weaverse/hydrogen to 5.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@shopify/hydrogen": "^2026.4.2",
         "@shopify/hydrogen-react": "^2026.4.2",
         "@tailwindcss/vite": "^4.3.0",
-        "@weaverse/hydrogen": "^5.15.1",
+        "@weaverse/hydrogen": "^5.15.2",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "colord": "2.9.3",
@@ -5505,23 +5505,23 @@
       "license": "MIT"
     },
     "node_modules/@weaverse/core": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@weaverse/core/-/core-5.15.1.tgz",
-      "integrity": "sha512-kmAuhjwLBAz5mVVoFBDrRrEdMaHyTk5WiBo5eRM+6fWBR+X3+2+lAITHbaezkp7QaFgnmMjeksAVLMISY2ABnA==",
+      "version": "5.15.2",
+      "resolved": "https://registry.npmjs.org/@weaverse/core/-/core-5.15.2.tgz",
+      "integrity": "sha512-e8rILJ/E+Jg9o217BGvcDqaXYQoOdE1/4TZZx8lFqQzhadhHo1EmOad2cfSVEP6YLIanBIHsdXY3MGKx0j9tqw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@weaverse/hydrogen": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@weaverse/hydrogen/-/hydrogen-5.15.1.tgz",
-      "integrity": "sha512-uLUQPaUx5tTJVvIo8Ia0vCMOSoacWhqW7PoV4CM9+Lpx3NcGLQKUCn8mPSyOgTaikFtuXrjh+lwxX3eoyTNhJg==",
+      "version": "5.15.2",
+      "resolved": "https://registry.npmjs.org/@weaverse/hydrogen/-/hydrogen-5.15.2.tgz",
+      "integrity": "sha512-AhS6bebHwdwdjoWUMGvEBNlvE678U01JmoZCuShaIh9O7byM6K3O3vzqa6I5GeVgo1uo45fQFYAF/wdXw+eaRA==",
       "license": "MIT",
       "dependencies": {
         "@shopify/hydrogen": ">=2025.5",
         "@shopify/remix-oxygen": "3",
-        "@weaverse/react": "5.15.1",
+        "@weaverse/react": "5.15.2",
         "@weaverse/schema": "0.9.0",
         "react": ">=19",
         "react-dom": ">=19",
@@ -5533,12 +5533,12 @@
       }
     },
     "node_modules/@weaverse/react": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@weaverse/react/-/react-5.15.1.tgz",
-      "integrity": "sha512-wD+a+UZhSULrrEex0N6Ydi7euqGNdRxHpiZEPXRmItnouNf6l+TpKjUKJteyuZhohHO6I/QM6Tgpn9TDmL3pAQ==",
+      "version": "5.15.2",
+      "resolved": "https://registry.npmjs.org/@weaverse/react/-/react-5.15.2.tgz",
+      "integrity": "sha512-uwu7oD7wlEpf+iYRu3423l6Ho8IFKtqvruZ9NrzlwViObVw4xfJHeNOBpy0oKOb8dk4sbQhgoRx4t3cplQbcug==",
       "license": "MIT",
       "dependencies": {
-        "@weaverse/core": "5.15.1",
+        "@weaverse/core": "5.15.2",
         "clsx": "^2.1.1",
         "react": ">=19",
         "react-dom": ">=19"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@shopify/hydrogen": "^2026.4.2",
     "@shopify/hydrogen-react": "^2026.4.2",
     "@tailwindcss/vite": "^4.3.0",
-    "@weaverse/hydrogen": "^5.15.1",
+    "@weaverse/hydrogen": "^5.15.2",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "colord": "2.9.3",


### PR DESCRIPTION
Analytics pixel dedupe for nested page compositions (one impression
per page per navigation; back/forward revisits count correctly).
