### PR TITLE
fix: deliver eager loading to the first slide via context

### DIFF
--- a/app/sections/slideshow/index.tsx
+++ b/app/sections/slideshow/index.tsx
@@ -5,7 +5,7 @@ import {
 import type { VariantProps } from "class-variance-authority";
 import { cva } from "class-variance-authority";
 import clsx from "clsx";
-import { cloneElement, isValidElement, type ReactElement } from "react";
+import { createContext } from "react";
 import { Autoplay, EffectFade, Navigation, Pagination } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { ScrollReveal } from "~/components/scroll-reveal";
@@ -15,6 +15,13 @@ import type { SlideshowArrowsProps } from "./arrows";
 import { Arrows } from "./arrows";
 import type { SlideshowDotsProps } from "./dots";
 import { Dots } from "./dots";
+/**
+ * True for the slideshow's first slide — its background is the LCP element
+ * on slideshow-led pages and must load eagerly. Weaverse wraps section
+ * children in its own item renderer, so a cloned prop would be dropped;
+ * context crosses that boundary (consumed in ./slide.tsx).
+ */
+export const EagerSlideContext = createContext(false);
 
 const variants = cva("group [&_.swiper]:h-full", {
   variants: {
@@ -135,13 +142,9 @@ export default function Slideshow(
       >
         {children.map((child, idx) => (
           <SwiperSlide key={idx} className="bg-white">
-            {/* The first slide is the LCP element on slideshow-led pages —
-                its background must load eagerly with high priority. */}
-            {isValidElement(child) && idx === 0
-              ? cloneElement(child as ReactElement<{ loading?: string }>, {
-                  loading: "eager",
-                })
-              : child}
+            <EagerSlideContext.Provider value={idx === 0}>
+              {child}
+            </EagerSlideContext.Provider>
           </SwiperSlide>
         ))}
         {showArrows && (

--- a/app/sections/slideshow/slide.tsx
+++ b/app/sections/slideshow/slide.tsx
@@ -5,11 +5,13 @@ import {
 } from "@weaverse/hydrogen";
 import type { VariantProps } from "class-variance-authority";
 import { cva } from "class-variance-authority";
+import { useContext } from "react";
 import { backgroundInputs } from "~/components/background-image";
 import { overlayInputs } from "~/components/overlay";
 import type { OverlayAndBackgroundProps } from "~/components/overlay-and-background";
 import { OverlayAndBackground } from "~/components/overlay-and-background";
 import { layoutInputs } from "~/components/section";
+import { EagerSlideContext } from "./index";
 
 const variants = cva("flex h-full w-full flex-col [&_.paragraph]:mx-[unset]", {
   variants: {
@@ -84,13 +86,15 @@ export default function Slide(props: SlideProps) {
     children,
     ...rest
   } = props;
+  // First slide of the slideshow loads its background eagerly (LCP).
+  const eagerSlide = useContext(EagerSlideContext);
   return (
     <div {...rest} className="h-full w-full">
       <OverlayAndBackground
         backgroundImage={backgroundImage}
         backgroundFit={backgroundFit}
         backgroundPosition={backgroundPosition}
-        loading={loading}
+        loading={eagerSlide ? "eager" : loading}
         enableOverlay={enableOverlay}
         overlayOpacity={overlayOpacity}
         overlayColor={overlayColor}


### PR DESCRIPTION
Follow-up to #405 — verified live that the cloneElement approach didn't work: Weaverse's item renderer wraps section children, dropping cloned props before they reach Slide. EagerSlideContext crosses that boundary; Slide consumes it and renders its background eager + fetchpriority=high. Build + typecheck green.