### PR TITLE
fix: derive hero-video height from intrinsic dimensions

### DIFF
--- a/app/sections/hero-video/index.tsx
+++ b/app/sections/hero-video/index.tsx
@@ -139,18 +139,40 @@ export default function HeroVideo(props: HeroVideoProps) {
       }
     }
 
+    if (mediaEl instanceof HTMLVideoElement) {
+      // Derive height from the INTRINSIC video dimensions, never from the
+      // rendered box: the container height is set from this value, and the
+      // video fills the container, so committing a rendered measurement can
+      // deadlock a wrong value (e.g. the 300x150 default before metadata
+      // loads — observed as an intermittently squashed hero).
+      if (mediaEl.videoWidth > 0 && mediaEl.videoHeight > 0) {
+        const containerWidth =
+          containerRef.current.getBoundingClientRect().width;
+        const intrinsicHeight =
+          (containerWidth * mediaEl.videoHeight) / mediaEl.videoWidth;
+        commitVideoHeight(intrinsicHeight);
+      }
+      // Metadata not loaded yet — skip; loadedmetadata/ResizeObserver will
+      // re-trigger this sync.
+      return;
+    }
     if (mediaEl) {
+      // Iframe embeds (YouTube/Vimeo) size themselves via aspect-ratio
+      // styles — the rendered box is the only available signal.
       const actualHeight = mediaEl.getBoundingClientRect().height;
       if (actualHeight > 0) {
-        // Only update if significantly different (> 2px) to avoid jitter
-        setVideoHeight((prev) => {
-          if (prev === null || Math.abs(prev - actualHeight) > 2) {
-            return actualHeight;
-          }
-          return prev;
-        });
+        commitVideoHeight(actualHeight);
       }
     }
+  }
+  function commitVideoHeight(next: number) {
+    // Only update if significantly different (> 2px) to avoid jitter
+    setVideoHeight((prev) => {
+      if (prev === null || Math.abs(prev - next) > 2) {
+        return next;
+      }
+      return prev;
+    });
   }
 
   /**


### PR DESCRIPTION
Follow-up to #407 — browser stress test (1.5Mbps throttle, 3 reloads) showed the ResizeObserver fix recovering in 2/3 runs but deadlocking in 1/3: committing the rendered 300x150 pre-metadata measurement locks the container, the video fills it, and no further resize ever fires. Height now derives from videoWidth/videoHeight intrinsics (skipped until metadata loads); iframes keep rendered-box measurement. Verification below in thread.