### PR TITLE
fix: defer cart_viewed analytics until the cart bootstrap resolves

### DIFF
--- a/app/components/cart/store.ts
+++ b/app/components/cart/store.ts
@@ -16,6 +16,14 @@ type CartStore = {
    * the SSR document (see entry.server.tsx full-page cache notes).
    */
   customerAccessToken: string | null;
+  /**
+   * True once the first /api/cart bootstrap response has been applied.
+   * Components whose analytics need an authoritative cart (e.g. the cart
+   * page's <Analytics.CartView>, whose publish effect is keyed on URL and
+   * never replays when the cart context updates) must wait for this —
+   * otherwise direct landings emit events with a null cart.
+   */
+  cartBootstrapped: boolean;
   open: () => void;
   close: () => void;
   toggle: (open?: boolean) => void;
@@ -25,6 +33,7 @@ export const useCartStore = create<CartStore>()((set) => ({
   isOpen: false,
   serverCart: null,
   customerAccessToken: null,
+  cartBootstrapped: false,
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false }),
   toggle: (open) =>
@@ -330,6 +339,7 @@ export function CartStoreSync() {
     }
     useCartStore.setState({
       customerAccessToken: payload.customerAccessToken,
+      cartBootstrapped: true,
     });
     const resolved = payload.cart;
     if (!resolved) {

--- a/app/routes/cart/cart-page.tsx
+++ b/app/routes/cart/cart-page.tsx
@@ -20,7 +20,7 @@ import {
 } from "react-router";
 import invariant from "tiny-invariant";
 import { CartMain } from "~/components/cart/cart-main";
-import { useCart } from "~/components/cart/store";
+import { useCart, useCartStore } from "~/components/cart/store";
 import { ProductCard } from "~/components/product-card";
 import { Section } from "~/components/section";
 import { Swimlane } from "~/components/swimlane";
@@ -153,7 +153,11 @@ export async function loader({ context }: LoaderFunctionArgs) {
 export default function CartRoute() {
   const { featuredProducts } = useLoaderData<typeof loader>();
   const cart = useCart();
-
+  // <Analytics.CartView> publishes once per URL and never replays when the
+  // provider's cart context updates later, so mounting it before the
+  // client-side cart bootstrap resolves would emit cart_viewed with a null
+  // cart on direct /cart landings.
+  const cartBootstrapped = useCartStore((s) => s.cartBootstrapped);
   return (
     <>
       <Section width="fixed" verticalPadding="medium" overflow="unset">
@@ -161,7 +165,7 @@ export default function CartRoute() {
           Cart ({cart?.totalQuantity || 0})
         </h1>
         <CartMain layout="page" cart={cart} />
-        <Analytics.CartView />
+        {cartBootstrapped && <Analytics.CartView />}
       </Section>
       <Suspense fallback={null}>
         <Await resolve={featuredProducts}>


### PR DESCRIPTION
Hydrogen's <Analytics.CartView> publishes once per URL (its effect is
keyed on [publish, url, shopId]) and never replays when the provider's
cart context updates afterwards. Since #401 moved the cart out of the
root loader, direct /cart landings emitted cart_viewed with a null cart
— losing attribution. Gate the component on a new cartBootstrapped
store flag set when the first /api/cart response is applied: it then
mounts with an authoritative (possibly legitimately empty) cart.

Surfaced by Codex review on the tilemall port (tilemall-hydrogen#4).
