### PR TITLE
fix: gate cart_viewed on the current cart bootstrap key

### DIFF
--- a/app/components/cart/store.ts
+++ b/app/components/cart/store.ts
@@ -17,13 +17,14 @@ type CartStore = {
    */
   customerAccessToken: string | null;
   /**
-   * True once the first /api/cart bootstrap response has been applied.
+   * Route navigation key whose /api/cart bootstrap response has been applied.
    * Components whose analytics need an authoritative cart (e.g. the cart
    * page's <Analytics.CartView>, whose publish effect is keyed on URL and
-   * never replays when the cart context updates) must wait for this —
-   * otherwise direct landings emit events with a null cart.
+   * never replays when the cart context updates) must wait until this equals
+   * the current `location.key` — a passive-effect boolean reset is too late
+   * to prevent child mount effects from publishing with the previous cart.
    */
-  cartBootstrapped: boolean;
+  cartBootstrapKey: string | null;
   open: () => void;
   close: () => void;
   toggle: (open?: boolean) => void;
@@ -33,7 +34,7 @@ export const useCartStore = create<CartStore>()((set) => ({
   isOpen: false,
   serverCart: null,
   customerAccessToken: null,
-  cartBootstrapped: false,
+  cartBootstrapKey: null,
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false }),
   toggle: (open) =>
@@ -257,6 +258,10 @@ export function useCart(): CartWithOptimistic | null {
       baselineSource = `fetcher(${fetcher.key})`;
       freshestFetcherCartRef.cart = cart;
       freshestFetcherCartRef.updatedAt = cart.updatedAt;
+      // This fallback scan is the only place that can see completed
+      // fetchers after React Router drops their components. Treat it as a
+      // real mutation sync for null-bootstrap race guards too.
+      cartMutationEpoch += 1;
     }
   }
 
@@ -327,15 +332,11 @@ export function CartStoreSync() {
   const apiCartPath = usePrefixPathWithLocale("/api/cart");
   const location = useLocation();
   const epochAtLoadRef = useRef(0);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: location.key intentionally re-bootstraps after every navigation (auth redirects, cookie-setting GET redirects)
   useEffect(() => {
     epochAtLoadRef.current = cartMutationEpoch;
-    // Drop the "bootstrapped" gate while a navigation re-load is in flight:
-    // GET flows can mutate the cart before landing (e.g. /discount/:code
-    // redirecting to /cart), and <Analytics.CartView> must wait for the
-    // corrected cart rather than publish the pre-navigation one.
-    useCartStore.setState({ cartBootstrapped: false });
-    load(apiCartPath);
+    const url = new URL(apiCartPath, window.location.origin);
+    url.searchParams.set("cartRequestKey", location.key);
+    load(url.pathname + url.search);
   }, [load, apiCartPath, location.key]);
   const payload = fetcher.data;
   useEffect(() => {
@@ -344,7 +345,7 @@ export function CartStoreSync() {
     }
     useCartStore.setState({
       customerAccessToken: payload.customerAccessToken,
-      cartBootstrapped: true,
+      cartBootstrapKey: payload.cartRequestKey ?? null,
     });
     const resolved = payload.cart;
     if (!resolved) {

--- a/app/routes/api/cart.ts
+++ b/app/routes/api/cart.ts
@@ -13,15 +13,21 @@ import { data } from "react-router";
  * `no-store`: this response IS personalized — it must never enter any
  * shared cache.
  */
-export async function loader({ context }: LoaderFunctionArgs) {
+export async function loader({ context, request }: LoaderFunctionArgs) {
   const { cart, customerAccount } = context;
+  const url = new URL(request.url);
+  const cartRequestKey = url.searchParams.get("cartRequestKey") ?? "";
   const [cartData, customerAccessToken] = await Promise.all([
     cart.get(),
     customerAccount.getAccessToken().catch(() => null),
   ]);
 
   return data(
-    { cart: cartData, customerAccessToken: customerAccessToken ?? null },
+    {
+      cart: cartData,
+      customerAccessToken: customerAccessToken ?? null,
+      cartRequestKey,
+    },
     { headers: { "Cache-Control": "no-store" } },
   );
 }

--- a/app/routes/cart/cart-page.tsx
+++ b/app/routes/cart/cart-page.tsx
@@ -17,6 +17,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
   useLoaderData,
+  useLocation,
 } from "react-router";
 import invariant from "tiny-invariant";
 import { CartMain } from "~/components/cart/cart-main";
@@ -153,11 +154,14 @@ export async function loader({ context }: LoaderFunctionArgs) {
 export default function CartRoute() {
   const { featuredProducts } = useLoaderData<typeof loader>();
   const cart = useCart();
+  const location = useLocation();
   // <Analytics.CartView> publishes once per URL and never replays when the
-  // provider's cart context updates later, so mounting it before the
-  // client-side cart bootstrap resolves would emit cart_viewed with a null
-  // cart on direct /cart landings.
-  const cartBootstrapped = useCartStore((s) => s.cartBootstrapped);
+  // provider's cart context updates later. Gate it on the bootstrap response
+  // for THIS navigation key — a store boolean flipped in a passive effect is
+  // too late to stop CartView's mount effect from publishing with the
+  // previous navigation's cart.
+  const cartBootstrapKey = useCartStore((s) => s.cartBootstrapKey);
+  const canPublishCartView = cartBootstrapKey === location.key;
   return (
     <>
       <Section width="fixed" verticalPadding="medium" overflow="unset">
@@ -165,7 +169,7 @@ export default function CartRoute() {
           Cart ({cart?.totalQuantity || 0})
         </h1>
         <CartMain layout="page" cart={cart} />
-        {cartBootstrapped && <Analytics.CartView />}
+        {canPublishCartView && <Analytics.CartView />}
       </Section>
       <Suspense fallback={null}>
         <Await resolve={featuredProducts}>


### PR DESCRIPTION
Codex found two real follow-ups on #411:

- resetting a boolean inside useEffect is too late for route-mount
  effects; /cart can mount <Analytics.CartView> before the effect flips
  the gate. /api/cart now echoes the navigation key and the cart page
  only mounts CartView when the applied bootstrap key equals the current
  location.key.

- the useCart() fallback scan can capture completed mutation fetchers
  after React Router drops their components, but it did not increment
  the mutation epoch. Treat fallback captures as real mutation syncs so
  an older cart:null bootstrap cannot clear the only retained copy.
