### PR TITLE
fix: use a unique cart bootstrap token for cart_viewed gating

### DIFF
--- a/app/components/cart/store.ts
+++ b/app/components/cart/store.ts
@@ -1,5 +1,5 @@
 import { CartForm } from "@shopify/hydrogen";
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import type { Fetcher } from "react-router";
 import { useFetcher, useFetchers, useLocation } from "react-router";
 import type { CartApiQueryFragment } from "storefront-api.generated";
@@ -17,14 +17,15 @@ type CartStore = {
    */
   customerAccessToken: string | null;
   /**
-   * Route navigation key whose /api/cart bootstrap response has been applied.
-   * Components whose analytics need an authoritative cart (e.g. the cart
-   * page's <Analytics.CartView>, whose publish effect is keyed on URL and
-   * never replays when the cart context updates) must wait until this equals
-   * the current `location.key` — a passive-effect boolean reset is too late
-   * to prevent child mount effects from publishing with the previous cart.
+   * Unique /api/cart bootstrap request token currently in flight, and the
+   * token whose response has been applied. Components whose analytics need an
+   * authoritative cart (e.g. <Analytics.CartView>, whose publish effect is
+   * keyed on URL and never replays when the cart context updates) must wait
+   * until these match. React Router history keys can be reused on back/forward
+   * navigation, so a per-request token is required.
    */
-  cartBootstrapKey: string | null;
+  cartBootstrapRequestToken: string | null;
+  cartBootstrapResponseToken: string | null;
   open: () => void;
   close: () => void;
   toggle: (open?: boolean) => void;
@@ -34,7 +35,8 @@ export const useCartStore = create<CartStore>()((set) => ({
   isOpen: false,
   serverCart: null,
   customerAccessToken: null,
-  cartBootstrapKey: null,
+  cartBootstrapRequestToken: null,
+  cartBootstrapResponseToken: null,
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false }),
   toggle: (open) =>
@@ -52,6 +54,11 @@ const freshestFetcherCartRef = {
  * pre-cookie bootstrap would wipe a cart the shopper just created.
  */
 let cartMutationEpoch = 0;
+
+let cartBootstrapRequestSeq = 0;
+
+const useHydrationSafeLayoutEffect =
+  typeof document === "undefined" ? useEffect : useLayoutEffect;
 
 /**
  * Module-level set of line IDs that have been optimistically removed.
@@ -332,10 +339,13 @@ export function CartStoreSync() {
   const apiCartPath = usePrefixPathWithLocale("/api/cart");
   const location = useLocation();
   const epochAtLoadRef = useRef(0);
-  useEffect(() => {
+  useHydrationSafeLayoutEffect(() => {
     epochAtLoadRef.current = cartMutationEpoch;
+    cartBootstrapRequestSeq += 1;
+    const cartRequestToken = `${location.key}:${cartBootstrapRequestSeq}`;
+    useCartStore.setState({ cartBootstrapRequestToken: cartRequestToken });
     const url = new URL(apiCartPath, window.location.origin);
-    url.searchParams.set("cartRequestKey", location.key);
+    url.searchParams.set("cartRequestToken", cartRequestToken);
     load(url.pathname + url.search);
   }, [load, apiCartPath, location.key]);
   const payload = fetcher.data;
@@ -345,7 +355,7 @@ export function CartStoreSync() {
     }
     useCartStore.setState({
       customerAccessToken: payload.customerAccessToken,
-      cartBootstrapKey: payload.cartRequestKey ?? null,
+      cartBootstrapResponseToken: payload.cartRequestToken ?? null,
     });
     const resolved = payload.cart;
     if (!resolved) {

--- a/app/routes/api/cart.ts
+++ b/app/routes/api/cart.ts
@@ -16,7 +16,7 @@ import { data } from "react-router";
 export async function loader({ context, request }: LoaderFunctionArgs) {
   const { cart, customerAccount } = context;
   const url = new URL(request.url);
-  const cartRequestKey = url.searchParams.get("cartRequestKey") ?? "";
+  const cartRequestToken = url.searchParams.get("cartRequestToken") ?? "";
   const [cartData, customerAccessToken] = await Promise.all([
     cart.get(),
     customerAccount.getAccessToken().catch(() => null),
@@ -26,7 +26,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     {
       cart: cartData,
       customerAccessToken: customerAccessToken ?? null,
-      cartRequestKey,
+      cartRequestToken,
     },
     { headers: { "Cache-Control": "no-store" } },
   );

--- a/app/routes/cart/cart-page.tsx
+++ b/app/routes/cart/cart-page.tsx
@@ -17,7 +17,6 @@ import {
   type LoaderFunctionArgs,
   redirect,
   useLoaderData,
-  useLocation,
 } from "react-router";
 import invariant from "tiny-invariant";
 import { CartMain } from "~/components/cart/cart-main";
@@ -154,14 +153,14 @@ export async function loader({ context }: LoaderFunctionArgs) {
 export default function CartRoute() {
   const { featuredProducts } = useLoaderData<typeof loader>();
   const cart = useCart();
-  const location = useLocation();
   // <Analytics.CartView> publishes once per URL and never replays when the
-  // provider's cart context updates later. Gate it on the bootstrap response
-  // for THIS navigation key — a store boolean flipped in a passive effect is
-  // too late to stop CartView's mount effect from publishing with the
-  // previous navigation's cart.
-  const cartBootstrapKey = useCartStore((s) => s.cartBootstrapKey);
-  const canPublishCartView = cartBootstrapKey === location.key;
+  // provider's cart context updates later. Gate it on a unique bootstrap
+  // request token rather than React Router's history key: back/forward can
+  // revisit a previous key, but the cart must be revalidated for this visit.
+  const requestToken = useCartStore((s) => s.cartBootstrapRequestToken);
+  const responseToken = useCartStore((s) => s.cartBootstrapResponseToken);
+  const canPublishCartView =
+    requestToken !== null && responseToken === requestToken;
   return (
     <>
       <Section width="fixed" verticalPadding="medium" overflow="unset">


### PR DESCRIPTION
React Router history keys are reused on back/forward navigation. A shopper
can revisit a previously bootstrapped /cart history entry before the new
/api/cart request resolves, making a location.key equality gate true with
the old cart.

Use a unique cartRequestToken for every bootstrap request, echoed by
/api/cart and recorded only when that response applies. The cart page now
mounts <Analytics.CartView> only when the current request token has a
matching response token. The request token is invalidated in a
hydration-safe layout effect so the stale CartView cannot publish before
passive effects run.
