### PR TITLE
fix: strip optimistic line data before creating carts

### DIFF
--- a/app/routes/cart/cart-page.tsx
+++ b/app/routes/cart/cart-page.tsx
@@ -54,7 +54,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
   switch (cartFormAction) {
     case CartForm.ACTIONS.LinesAdd: {
-      const lines = inputs.lines as CartLineInput[];
+      const lines = getCartLineInputs(inputs.lines as CartLineInput[]);
       if (!cart.getCartId()) {
         result = await cart.create({
           lines,
@@ -197,6 +197,17 @@ export default function CartRoute() {
   );
 }
 
+function getCartLineInputs(lines: CartLineInput[]): CartLineInput[] {
+  return lines.map(
+    ({ attributes, merchandiseId, parent, quantity, sellingPlanId }) => ({
+      attributes,
+      merchandiseId,
+      parent,
+      quantity,
+      sellingPlanId,
+    }),
+  );
+}
 function getCountryCodeFromRequestOrReferer(
   request: Request,
   fallbackCountryCode: CountryCode,


### PR DESCRIPTION
CartForm includes client-only optimistic data such as selectedVariant in
posted line inputs. Hydrogen's cart.addLines() strips those fields, but
our no-cookie branch bypassed it and called cart.create({ lines })
directly so Shopify rejected the CartInput variables and /cart.data
returned a sanitized server error. Sanitize LinesAdd input before both
cart.create and cart.addLines so first add-to-cart creates a cart again.
