### PR TITLE
fix: invalidate cart bootstrap token during render

### DIFF
--- a/app/components/cart/store.ts
+++ b/app/components/cart/store.ts
@@ -56,6 +56,30 @@ const freshestFetcherCartRef = {
 let cartMutationEpoch = 0;
 
 let cartBootstrapRequestSeq = 0;
+let currentCartBootstrapLocationKey = "";
+let currentCartBootstrapPath = "";
+let currentCartBootstrapRequestToken: string | null = null;
+const cartBootstrapEpochByToken = new Map<string, number>();
+
+function ensureCartBootstrapRequestToken(locationKey: string, path: string) {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  if (
+    currentCartBootstrapLocationKey !== locationKey ||
+    currentCartBootstrapPath !== path
+  ) {
+    cartBootstrapRequestSeq += 1;
+    currentCartBootstrapLocationKey = locationKey;
+    currentCartBootstrapPath = path;
+    currentCartBootstrapRequestToken = `${locationKey}:${cartBootstrapRequestSeq}`;
+  }
+  return currentCartBootstrapRequestToken;
+}
+
+export function getCurrentCartBootstrapRequestToken() {
+  return currentCartBootstrapRequestToken;
+}
 
 const useHydrationSafeLayoutEffect =
   typeof document === "undefined" ? useEffect : useLayoutEffect;
@@ -338,30 +362,41 @@ export function CartStoreSync() {
   const load = fetcher.load;
   const apiCartPath = usePrefixPathWithLocale("/api/cart");
   const location = useLocation();
-  const epochAtLoadRef = useRef(0);
+  const cartRequestToken = ensureCartBootstrapRequestToken(
+    location.key,
+    apiCartPath,
+  );
   useHydrationSafeLayoutEffect(() => {
-    epochAtLoadRef.current = cartMutationEpoch;
-    cartBootstrapRequestSeq += 1;
-    const cartRequestToken = `${location.key}:${cartBootstrapRequestSeq}`;
+    if (!cartRequestToken) {
+      return;
+    }
+    cartBootstrapEpochByToken.set(cartRequestToken, cartMutationEpoch);
     useCartStore.setState({ cartBootstrapRequestToken: cartRequestToken });
     const url = new URL(apiCartPath, window.location.origin);
     url.searchParams.set("cartRequestToken", cartRequestToken);
     load(url.pathname + url.search);
-  }, [load, apiCartPath, location.key]);
+  }, [load, apiCartPath, cartRequestToken]);
   const payload = fetcher.data;
   useEffect(() => {
     if (!payload) {
       return;
     }
+    const responseToken = payload.cartRequestToken ?? null;
+    if (
+      !responseToken ||
+      responseToken !== getCurrentCartBootstrapRequestToken()
+    ) {
+      return;
+    }
     useCartStore.setState({
       customerAccessToken: payload.customerAccessToken,
-      cartBootstrapResponseToken: payload.cartRequestToken ?? null,
+      cartBootstrapResponseToken: responseToken,
     });
     const resolved = payload.cart;
     if (!resolved) {
       // Only clear when no mutation synced since this load was issued —
       // a slow pre-cookie bootstrap must not wipe a just-created cart.
-      if (cartMutationEpoch === epochAtLoadRef.current) {
+      if (cartMutationEpoch === cartBootstrapEpochByToken.get(responseToken)) {
         // Reset the module ref too: useCart() consults it before the store,
         // so a surviving entry would keep resurrecting a cart whose cookie
         // expired or was completed at checkout.

--- a/app/routes/cart/cart-page.tsx
+++ b/app/routes/cart/cart-page.tsx
@@ -20,7 +20,11 @@ import {
 } from "react-router";
 import invariant from "tiny-invariant";
 import { CartMain } from "~/components/cart/cart-main";
-import { useCart, useCartStore } from "~/components/cart/store";
+import {
+  getCurrentCartBootstrapRequestToken,
+  useCart,
+  useCartStore,
+} from "~/components/cart/store";
 import { ProductCard } from "~/components/product-card";
 import { Section } from "~/components/section";
 import { Swimlane } from "~/components/swimlane";
@@ -154,10 +158,11 @@ export default function CartRoute() {
   const { featuredProducts } = useLoaderData<typeof loader>();
   const cart = useCart();
   // <Analytics.CartView> publishes once per URL and never replays when the
-  // provider's cart context updates later. Gate it on a unique bootstrap
-  // request token rather than React Router's history key: back/forward can
-  // revisit a previous key, but the cart must be revalidated for this visit.
-  const requestToken = useCartStore((s) => s.cartBootstrapRequestToken);
+  // provider's cart context updates later. CartStoreSync (rendered above the
+  // route tree) synchronously advances the current request token during
+  // render; this prevents a back/forward visit from reusing a previous
+  // matching token before effects run.
+  const requestToken = getCurrentCartBootstrapRequestToken();
   const responseToken = useCartStore((s) => s.cartBootstrapResponseToken);
   const canPublishCartView =
     requestToken !== null && responseToken === requestToken;


### PR DESCRIPTION
A layout-effect token reset is still too late for <Analytics.CartView>:
React can flush passive effects from the just-committed route before the
layout-effect update prevents the stale match. Since CartStoreSync renders
above the route tree, advance the current bootstrap request token
synchronously during render, then have CartView compare the applied response
token with that render-time token.

Also key null-bootstrap epoch snapshots by request token so late responses
from older requests cannot compare against a newer load's epoch.
