### PR TITLE
fix: hold cart drawer body until the first cart bootstrap resolves

### DIFF
--- a/app/components/cart/cart-drawer.tsx
+++ b/app/components/cart/cart-drawer.tsx
@@ -6,11 +6,17 @@ import { useEffect } from "react";
 import { useLocation } from "react-router";
 import { CartMain } from "~/components/cart/cart-main";
 import Link from "~/components/link";
-import { useCart, useCartStore } from "./store";
+import { Spinner } from "~/components/spinner";
+import { useCart, useCartBootstrapResolved, useCartStore } from "./store";
 
 export function CartDrawer() {
   const { publish } = useAnalytics();
   const cart = useCart();
+  // Returning shoppers have a cart cookie but useCart() stays null until the
+  // /api/cart bootstrap responds — rendering CartMain then would show a
+  // false "empty cart". Hold a loading state until the first response lands
+  // (the old root-loader Await behaved the same way).
+  const cartBootstrapResolved = useCartBootstrapResolved();
   const {
     isOpen,
     close: closeCartDrawer,
@@ -71,7 +77,8 @@ export function CartDrawer() {
                   className="group/cart-title flex items-center gap-1.5 text-lg font-serif font-semibold hover:underline"
                   onClick={closeCartDrawer}
                 >
-                  Cart ({cart?.totalQuantity || 0})
+                  Cart
+                  {cartBootstrapResolved && ` (${cart?.totalQuantity || 0})`}
                   <ArrowRightIcon className="size-4 transition-transform group-hover/cart-title:translate-x-0.5" />
                 </Link>
               </Dialog.Title>
@@ -85,7 +92,17 @@ export function CartDrawer() {
                 </button>
               </Dialog.Close>
             </div>
-            <CartMain layout="drawer" cart={cart} />
+            {cartBootstrapResolved ? (
+              <CartMain layout="drawer" cart={cart} />
+            ) : (
+              <div
+                className="relative grow"
+                role="status"
+                aria-label="Loading cart"
+              >
+                <Spinner />
+              </div>
+            )}
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/app/components/cart/store.ts
+++ b/app/components/cart/store.ts
@@ -80,6 +80,20 @@ function ensureCartBootstrapRequestToken(locationKey: string, path: string) {
 export function getCurrentCartBootstrapRequestToken() {
   return currentCartBootstrapRequestToken;
 }
+/**
+ * True once ANY /api/cart bootstrap response has been applied this session.
+ * Pre-bootstrap, `useCart()` returns null for returning shoppers too, so
+ * cart-presenting UI (the drawer body) must not render its empty-cart state
+ * yet — that matches the old root-loader behavior where those surfaces sat
+ * behind a Suspense fallback until the deferred cart resolved, and the
+ * resolved promise then persisted across navigations. (Per-navigation
+ * freshness gates like <Analytics.CartView> use the request-token match
+ * instead.)
+ */
+export function useCartBootstrapResolved() {
+  const responseToken = useCartStore((s) => s.cartBootstrapResponseToken);
+  return responseToken !== null;
+}
 
 const useHydrationSafeLayoutEffect =
   typeof document === "undefined" ? useEffect : useLayoutEffect;


### PR DESCRIPTION
Returning shoppers have a cart cookie but useCart() stays null until the
client /api/cart bootstrap responds, so opening the drawer early rendered
CartMain's empty-cart state as if the cart were genuinely empty. Gate the
drawer body on a new useCartBootstrapResolved() hook (first applied
bootstrap response, persistent across navigations — the same semantics as
the old root-loader Await fallback): a centered spinner shows until then
and the title omits the count.

Surfaced by review on the kids2 port (kids2-baby-einstein-hydrogen#148).
