### PR TITLE
perf: serve responsive srcsets instead of fixed-width images

### DIFF
--- a/app/components/product-card/index.tsx
+++ b/app/components/product-card/index.tsx
@@ -151,7 +151,6 @@ export function ProductCard({
             ])}
             sizes="(min-width: 64em) 25vw, (min-width: 48em) 30vw, 45vw"
             data={image}
-            width={700}
             alt={image.altText || `Picture of ${product.title}`}
             loading={aboveTheFold ? "eager" : "lazy"}
             onLoad={() => setIsImageLoading(false)}
@@ -162,8 +161,7 @@ export function ProductCard({
                 "absolute inset-0",
                 "opacity-0 transition-opacity duration-300 group-hover:opacity-100",
               ])}
-              sizes="auto"
-              width={700}
+              sizes="(min-width: 64em) 25vw, (min-width: 48em) 30vw, 45vw"
               data={secondImage}
               alt={secondImage.altText || `Second picture of ${product.title}`}
               loading="lazy"

--- a/app/components/product-media/media-item.tsx
+++ b/app/components/product-media/media-item.tsx
@@ -41,7 +41,6 @@ export function MediaItem({
         loading={index === 0 ? "eager" : "lazy"}
         fetchPriority={index === 0 ? "high" : undefined}
         className={cn("h-auto w-full object-cover", className)}
-        width={2048}
         aspectRatio={calculateAspectRatio(image, imageAspectRatio)}
         sizes={sizes}
       />

--- a/app/sections/main-collection/collection-header/index.tsx
+++ b/app/sections/main-collection/collection-header/index.tsx
@@ -76,7 +76,7 @@ function CollectionHeader(props: CollectionHeaderProps) {
               } as React.CSSProperties
             }
           >
-            <Image data={banner} sizes="auto" width={2000} />
+            <Image data={banner} sizes="(min-width: 1024px) 50vw, 100vw" />
           </div>
         )}
       </div>


### PR DESCRIPTION
Hydrogen's <Image> with a numeric width renders FixedWidthImage, whose
srcset is density-based ([w, 2w, 3w]) and ignores the sizes attribute —
so the PDP gallery shipped >=2048w files into a ~50vw slot (Lighthouse:
2,041 KB image-delivery savings, top offender 397 KB at width=2048).
Dropping the numeric width switches to FluidImage's w-descriptor srcset
(200-3000w), letting the existing sizes media conditions pick the right
candidate:

- product-media/media-item: width=2048 removed; sizes already correct
- product-card: width=700 removed for both images; hover image's
  sizes="auto" replaced with the primary image's conditions (same box)
- collection-header banner: width=2000 + sizes="auto" replaced with
  (min-width: 1024px) 50vw, 100vw to match the lg:w-1/2 container

media-zoom keeps width=4096 deliberately (zoom canvas).
