### PR TITLE
perf: lazy-load Shopify account web components on intent

### DIFF
--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -1,6 +1,8 @@
 import { MagnifyingGlassIcon, UserIcon } from "@phosphor-icons/react";
+import { useNonce } from "@shopify/hydrogen";
 import { useThemeSettings } from "@weaverse/hydrogen";
 import { cva } from "class-variance-authority";
+import { useEffect, useRef, useState } from "react";
 import { useLocation, useRouteError, useRouteLoaderData } from "react-router";
 import useWindowScroll from "react-use/esm/useWindowScroll";
 import { CartDrawer } from "~/components/cart/cart-drawer";
@@ -33,6 +35,84 @@ const variants = cva("", {
     },
   },
 });
+
+const STOREFRONT_WEB_COMPONENTS_SRC =
+  "https://cdn.shopify.com/storefront/web-components.js";
+const ACCOUNT_WEB_COMPONENTS_SRC =
+  "https://cdn.shopify.com/storefront/web-components/account.js";
+
+let shopifyAccountComponentsPromise: Promise<void> | null = null;
+
+function loadModuleScript(src: string, nonce?: string) {
+  return new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${src}"]`,
+    );
+    if (existing) {
+      if (existing.dataset.loaded === "true") {
+        resolve();
+        return;
+      }
+      existing.addEventListener("load", () => resolve(), { once: true });
+      existing.addEventListener(
+        "error",
+        () => reject(new Error(`Failed to load ${src}`)),
+        { once: true },
+      );
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.type = "module";
+    script.src = src;
+    if (nonce) {
+      script.nonce = nonce;
+    }
+    script.addEventListener(
+      "load",
+      () => {
+        script.dataset.loaded = "true";
+        resolve();
+      },
+      { once: true },
+    );
+    script.addEventListener(
+      "error",
+      () => reject(new Error(`Failed to load ${src}`)),
+      { once: true },
+    );
+    document.head.appendChild(script);
+  });
+}
+
+function loadShopifyAccountComponents(nonce?: string) {
+  if (typeof document === "undefined") {
+    return Promise.resolve();
+  }
+  if (
+    customElements.get("shopify-store") &&
+    customElements.get("shopify-account")
+  ) {
+    return Promise.resolve();
+  }
+
+  shopifyAccountComponentsPromise ??= (async () => {
+    // account.js otherwise defines window.Shopify as non-configurable before
+    // Hydrogen analytics gets a chance to define/update it. Keep this here too
+    // so intent-loading stays safe even if root.tsx's tiny bootstrap script is
+    // ever removed.
+    const shopifyWindow = window as Window & {
+      Shopify?: Record<string, unknown>;
+    };
+    shopifyWindow.Shopify = shopifyWindow.Shopify || {};
+    await loadModuleScript(STOREFRONT_WEB_COMPONENTS_SRC, nonce);
+    await customElements.whenDefined("shopify-store");
+    await loadModuleScript(ACCOUNT_WEB_COMPONENTS_SRC, nonce);
+    await customElements.whenDefined("shopify-account");
+  })();
+
+  return shopifyAccountComponentsPromise;
+}
 
 function useIsHomeCheck() {
   const { pathname } = useLocation();
@@ -123,20 +203,67 @@ export function Header() {
 }
 
 function ShopifyAccountButton() {
-  let rootData = useRouteLoaderData<RootLoader>("root");
-  let publicStoreDomain = rootData?.publicStoreDomain;
-  let publicAccessToken = rootData?.consent?.storefrontAccessToken;
+  const nonce = useNonce();
+  const accountRef = useRef<HTMLElement>(null);
+  const shouldOpenWhenReadyRef = useRef(false);
+  const rootData = useRouteLoaderData<RootLoader>("root");
+  const publicStoreDomain = rootData?.publicStoreDomain;
+  const publicAccessToken = rootData?.consent?.storefrontAccessToken;
+  const [componentsReady, setComponentsReady] = useState(
+    () =>
+      typeof customElements !== "undefined" &&
+      customElements.get("shopify-store") !== undefined &&
+      customElements.get("shopify-account") !== undefined,
+  );
+  const [isLoading, setIsLoading] = useState(false);
   // Bootstrapped client-side via /api/cart (CartStoreSync) — the token must
   // not be embedded in the SSR document, which stays anonymous so Oxygen
   // can full-page cache it.
-  let customerAccessToken = useCartStore((state) => state.customerAccessToken);
+  const customerAccessToken = useCartStore(
+    (state) => state.customerAccessToken,
+  );
   // Until the auth state is known — first bootstrap response, re-checked
   // after auth-mutating navigations like the logout redirect — mounting an
   // active <shopify-account> with a stale/null token would open the wrong
   // flow for shoppers who click during that window. Render an inert icon
   // instead (the old Suspense fallback, which also re-suspended after
   // actions revalidated the root loader's token promise).
-  let customerAccessTokenKnown = useCustomerAccessTokenKnown();
+  const customerAccessTokenKnown = useCustomerAccessTokenKnown();
+
+  function warmAccountComponents(openWhenReady = false) {
+    if (!(customerAccessTokenKnown && publicAccessToken && publicStoreDomain)) {
+      return;
+    }
+    if (componentsReady) {
+      if (openWhenReady) {
+        accountRef.current?.click();
+      }
+      return;
+    }
+    if (openWhenReady) {
+      shouldOpenWhenReadyRef.current = true;
+      setIsLoading(true);
+    }
+    loadShopifyAccountComponents(nonce)
+      .then(() => {
+        setComponentsReady(true);
+      })
+      .catch(() => {
+        shouldOpenWhenReadyRef.current = false;
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }
+
+  useEffect(() => {
+    if (!(componentsReady && shouldOpenWhenReadyRef.current)) {
+      return;
+    }
+    shouldOpenWhenReadyRef.current = false;
+    requestAnimationFrame(() => accountRef.current?.click());
+  }, [componentsReady]);
+
   if (!customerAccessTokenKnown) {
     return (
       <span aria-hidden="true">
@@ -144,13 +271,30 @@ function ShopifyAccountButton() {
       </span>
     );
   }
+
+  if (!componentsReady) {
+    return (
+      <button
+        type="button"
+        className="flex h-8 w-8 items-center justify-center focus-visible:outline-hidden"
+        aria-label={isLoading ? "Loading account" : "Account"}
+        aria-busy={isLoading || undefined}
+        onClick={() => warmAccountComponents(true)}
+        onFocus={() => warmAccountComponents()}
+        onPointerEnter={() => warmAccountComponents()}
+      >
+        <UserIcon className="h-5 w-5" />
+      </button>
+    );
+  }
+
   return (
     <shopify-store
       store-domain={publicStoreDomain}
       public-access-token={publicAccessToken}
       customer-access-token={customerAccessToken || undefined}
     >
-      <shopify-account sign-in-url="/account/login">
+      <shopify-account ref={accountRef} sign-in-url="/account/login">
         <span slot="signed-out-avatar">
           <UserIcon className="h-5 w-5" />
         </span>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -158,38 +158,11 @@ export const Layout = withWeaverse(function RootLayout({
         <Links />
         <GlobalStyle />
         {/*
-         * Shopify Storefront Web Components are split across two disjoint
-         * feature bundles (NOT umbrella vs per-component):
-         *   web-components.js          → <shopify-store>, <shopify-cart>,
-         *                                 <shopify-catalog>, <shopify-context>,
-         *                                 <shopify-data>, <shopify-media>, …
-         *   web-components/account.js  → <shopify-account>,
-         *                                 <shopify-customer-account-data>
-         *
-         * <shopify-account> is rendered inside <shopify-store> in this header
-         * so both bundles must be loaded. account.js does dynamic-import a
-         * chunked store-*.js to register <shopify-store>, but the chunk
-         * arrives AFTER <shopify-account>'s connectedCallback fires, which
-         * emits the visible warning
-         *   [shopify-account] <shopify-store> custom element is not registered
-         * and the account widget renders an empty slot.
-         *
-         * Use `defer` (not `async`): module scripts execute in document order
-         * with defer, which is required — if account.js runs before
-         * web-components.js, the same warning fires.
+         * Shopify Storefront Web Components are large third-party bundles.
+         * Do NOT load them in the document head: the header account button
+         * lazy-loads them on hover/focus/click instead, preserving the
+         * required script order (web-components.js before account.js).
          */}
-        <script
-          type="module"
-          src="https://cdn.shopify.com/storefront/web-components.js"
-          defer
-          nonce={nonce}
-        />
-        <script
-          type="module"
-          src="https://cdn.shopify.com/storefront/web-components/account.js"
-          defer
-          nonce={nonce}
-        />
       </head>
       <body
         style={


### PR DESCRIPTION
The Shopify Storefront Web Component bundles are large third-party JS and
were loaded from the document head on every page, even though they are
only needed when the shopper uses the header account icon.

Keep the tiny window.Shopify bootstrap, but remove the root-level module
scripts. The account button now:

- renders an inert icon until auth state is known (existing gate)
- preloads web-components.js then account.js on hover/focus
- loads on click if needed, then programmatically clicks the mounted
  <shopify-account> once both custom elements are defined
- preserves the required script order (store bundle before account
  bundle) to avoid the <shopify-store> registration warning

This takes shop-js out of the initial page-load critical path while
keeping account UX intact.
