### PR TITLE
fix: remove stabilized React Router future flag override

### DIFF
--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -6,10 +6,4 @@ export default {
   appDirectory: "app",
   buildDirectory: "dist",
   ssr: true,
-  // Silence the React Router future-flag warning without changing runtime
-  // behavior. RR 7.16 exposes this as an `unstable_` option; keep current
-  // trailing-slash data-request behavior until Hydrogen validates the v8 path.
-  future: {
-    unstable_trailingSlashAwareDataRequests: false,
-  },
 } satisfies Config;


### PR DESCRIPTION
The Hydrogen deploy command rejects the
config because the flag has stabilized in the deployment toolchain, while
local TypeScript on the current package set rejected the v8-prefixed name.
The preset already owns the future config; remove the override entirely so
both local typecheck and Oxygen deploy use the toolchain defaults.
