### PR TITLE
Bump @weaverse/hydrogen to 5.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@shopify/hydrogen": "^2026.4.3",
         "@shopify/hydrogen-react": "^2026.4.3",
         "@tailwindcss/vite": "^4.3.0",
-        "@weaverse/hydrogen": "^5.15.2",
+        "@weaverse/hydrogen": "^5.16.0",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "colord": "2.9.3",
@@ -6007,23 +6007,23 @@
       "license": "MIT"
     },
     "node_modules/@weaverse/core": {
-      "version": "5.15.2",
-      "resolved": "https://registry.npmjs.org/@weaverse/core/-/core-5.15.2.tgz",
-      "integrity": "sha512-e8rILJ/E+Jg9o217BGvcDqaXYQoOdE1/4TZZx8lFqQzhadhHo1EmOad2cfSVEP6YLIanBIHsdXY3MGKx0j9tqw==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@weaverse/core/-/core-5.16.0.tgz",
+      "integrity": "sha512-ynOWY7jRiZWVu8+9ZLXKqyBSU2NWXKOPJdhUplcYmYSxFN2fJag4ao5F65FDnkeZhzkJeUJk2jn3i/wiYJj1mw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@weaverse/hydrogen": {
-      "version": "5.15.2",
-      "resolved": "https://registry.npmjs.org/@weaverse/hydrogen/-/hydrogen-5.15.2.tgz",
-      "integrity": "sha512-AhS6bebHwdwdjoWUMGvEBNlvE678U01JmoZCuShaIh9O7byM6K3O3vzqa6I5GeVgo1uo45fQFYAF/wdXw+eaRA==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@weaverse/hydrogen/-/hydrogen-5.16.0.tgz",
+      "integrity": "sha512-0cBY60bZ0hpu6fuwWCSx3Qo//yKp+jk2O8DO8/3tDB6gG8J28F3xYB557iHC3d/4AzIX1vawSnptbVE9bvfjzw==",
       "license": "MIT",
       "dependencies": {
         "@shopify/hydrogen": ">=2025.5",
         "@shopify/remix-oxygen": "3",
-        "@weaverse/react": "5.15.2",
+        "@weaverse/react": "5.16.0",
         "@weaverse/schema": "0.9.0",
         "react": ">=19",
         "react-dom": ">=19",
@@ -6035,12 +6035,12 @@
       }
     },
     "node_modules/@weaverse/react": {
-      "version": "5.15.2",
-      "resolved": "https://registry.npmjs.org/@weaverse/react/-/react-5.15.2.tgz",
-      "integrity": "sha512-uwu7oD7wlEpf+iYRu3423l6Ho8IFKtqvruZ9NrzlwViObVw4xfJHeNOBpy0oKOb8dk4sbQhgoRx4t3cplQbcug==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@weaverse/react/-/react-5.16.0.tgz",
+      "integrity": "sha512-60wqsdZo4W21On36HXUyJZLZduxGQQaAT1yg4SME5vRSlOrDQOnlGfQ5QUvlonL691ySDWHWzU376DdDax4kqg==",
       "license": "MIT",
       "dependencies": {
-        "@weaverse/core": "5.15.2",
+        "@weaverse/core": "5.16.0",
         "clsx": "^2.1.1",
         "react": ">=19",
         "react-dom": ">=19"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@shopify/hydrogen": "^2026.4.3",
     "@shopify/hydrogen-react": "^2026.4.3",
     "@tailwindcss/vite": "^4.3.0",
-    "@weaverse/hydrogen": "^5.15.2",
+    "@weaverse/hydrogen": "^5.16.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "colord": "2.9.3",


### PR DESCRIPTION
Bumps `@weaverse/hydrogen` to `5.16.0` (core/react/hydrogen lockstep). This release adds `WEAVERSE_PUBLIC_API_BASE` support and defaults public project/config/custom-page reads to the `api.weaverse.io` edge cache. No env change needed — the SDK defaults to `api.weaverse.io` while keeping `studio.weaverse.io` for editor/preview.

Lockfile only updates the three `@weaverse/*` packages to `5.16.0`.