### PR TITLE
fix(i18n): derive schema defaultLocale from DEFAULT_LOCALE (Weaverse/builder#2266)

### DIFF
--- a/app/utils/const.ts
+++ b/app/utils/const.ts
@@ -1,5 +1,10 @@
 import type { I18nLocale, Localizations } from "~/types/others";
 
+// The `default` entry is the single source of truth for the storefront's
+// default locale: `DEFAULT_LOCALE` (below) spreads it, and `themeSchema.i18n.
+// defaultLocale` reuses that — which is also what Weaverse Studio's Translation
+// Manager reads as the base language. Change `default` here (e.g. to en-CH) and
+// both the runtime locale and the Studio base language follow.
 export const COUNTRIES: Localizations = {
   default: {
     label: "United States (USD $)",

--- a/app/weaverse/schema.server.ts
+++ b/app/weaverse/schema.server.ts
@@ -1,5 +1,5 @@
 import type { HydrogenThemeSchema } from "@weaverse/hydrogen";
-import { COUNTRIES } from "~/utils/const";
+import { COUNTRIES, DEFAULT_LOCALE } from "~/utils/const";
 import { version } from "../../package.json";
 import { announcementSettings } from "./settings/announcements";
 import { cartSettings } from "./settings/cart";
@@ -25,13 +25,7 @@ export const themeSchema: HydrogenThemeSchema = {
   },
   i18n: {
     urlStructure: "url-path",
-    defaultLocale: {
-      pathPrefix: "",
-      label: "United States (USD $)",
-      language: "EN",
-      country: "US",
-      currency: "USD",
-    },
+    defaultLocale: DEFAULT_LOCALE,
     shopLocales: Object.entries(COUNTRIES).map(
       ([pathPrefix, { label, language, country }]) => {
         return {


### PR DESCRIPTION
## Summary

Pilot hardcoded the default locale **twice** — `COUNTRIES.default` in `app/utils/const.ts` and an inline `i18n.defaultLocale` block in `app/weaverse/schema.server.ts`. A merchant changing their default locale (e.g. en-CH) had to edit both, and editing only one left the runtime locale and the Weaverse Studio Translation Manager base language out of sync.

A Swiss merchant (Tuftinglove) hit exactly this: Translation Manager kept showing `en-us` as the base because the schema hardcodes `country: "US"`.

## Change

Derive the schema's `defaultLocale` from the existing `DEFAULT_LOCALE` export (single source of truth):

```diff
-import { COUNTRIES } from "~/utils/const";
+import { COUNTRIES, DEFAULT_LOCALE } from "~/utils/const";

   i18n: {
     urlStructure: "url-path",
-    defaultLocale: {
-      pathPrefix: "",
-      label: "United States (USD $)",
-      language: "EN",
-      country: "US",
-      currency: "USD",
-    },
+    defaultLocale: DEFAULT_LOCALE,
```

`DEFAULT_LOCALE = Object.freeze({ ...COUNTRIES.default, pathPrefix: "" })`, so this is **behavior-identical** — same fields, same values — just de-duplicated. Now changing `COUNTRIES.default` is the only edit needed.

Also added a short comment above `COUNTRIES` explaining that the `default` entry drives both the runtime default locale and the Studio Translation Manager base language.

## Verification

- `biome check` clean on both files.
- `tsc --noEmit`: my files produce zero errors (the 2 pre-existing `getWeaverseSeoMeta` errors in `catch-all.tsx`/`home.tsx` are present on `main` without this change — unrelated dependency drift).
- The same `defaultLocale: DEFAULT_LOCALE` pattern is already used in the THE OUTNET storefront, so the type is proven compatible.

Resolves Weaverse/builder#2266
