### PR TITLE
feat(experiments): add @weaverse/experiments for framework-agnostic A/B testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ turbo test --filter=@weaverse/hydrogen
 @weaverse/i18n              ← internationalization
 @weaverse/next              ← Next.js integration
 @weaverse/remix             ← Remix integration
+@weaverse/experiments       ← A/B testing (independent; zero-dep engine + optional react peer)
 ```
 
 ### Key Directories
@@ -67,6 +68,7 @@ packages/
   i18n/          Internationalization utilities
   next/          Next.js integration
   remix/         Remix integration
+  experiments/   Framework-agnostic A/B testing (engine + /server + /react)
 templates/
   pilot/         Example Hydrogen storefront theme
 archived/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -160,6 +160,7 @@ $ pnpm run build (orchestrated by Turbo)
      ├─→ @weaverse/schema (no deps)
      ├─→ @weaverse/biome (no deps)
      ├─→ @weaverse/i18n (no deps)
+     ├─→ @weaverse/experiments (no deps)
      │
      ├─→ @weaverse/react (depends on core)
      ├─→ @weaverse/cli (no deps)

--- a/packages/experiments/.gitignore
+++ b/packages/experiments/.gitignore
@@ -1,0 +1,5 @@
+*.log
+.DS_Store
+node_modules
+.cache
+dist

--- a/packages/experiments/CHANGELOG.md
+++ b/packages/experiments/CHANGELOG.md
@@ -1,0 +1,17 @@
+# @weaverse/experiments
+
+## 0.1.0
+
+Initial release — framework-agnostic A/B testing and experimentation.
+
+- **Engine (`@weaverse/experiments`)** — zero-dependency, deterministic variant
+  assignment via FNV-1a bucketing. `assignVariant`, `resolveExperiments`,
+  `stableSeed`, `hashToBucket`. Sticky without storage; weighted splits; per-run
+  salt; variant-to-`projectId` mapping for project-level experiments.
+- **Server adapter (`@weaverse/experiments/server`)** — `getExperiments(request,
+  config)` built on web standards (`Request`/`Headers`/`crypto`). Mints a stable
+  `_wv_vid` visitor seed once, resolves assignments, and maps the chosen variant
+  to a Weaverse `projectId`. Runs on Hydrogen, Workers, Next.js, Remix, Deno, Bun.
+- **React bindings (`@weaverse/experiments/react`)** — `<WeaverseExperiments>`
+  provider with fire-once exposure events (bring your own analytics),
+  `useExperiment`, `useExperiments`. `react` is an optional peer dependency.

--- a/packages/experiments/LICENSE
+++ b/packages/experiments/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Weaverse
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -112,7 +112,9 @@ at two seams:
 ```tsx
 // app/root.tsx
 import { Analytics, useAnalytics } from '@shopify/hydrogen'
+import type { Assignment } from '@weaverse/experiments'
 import { WeaverseExperiments } from '@weaverse/experiments/react'
+import type { ReactNode } from 'react'
 
 export default function App() {
   let { assignments, cart, shop, consent } = useLoaderData<typeof loader>()
@@ -127,25 +129,43 @@ export default function App() {
         ),
       }}
     >
-      <ExperimentExposure assignments={assignments} />
-      <Outlet />
+      <Experiments assignments={assignments}>
+        <Outlet />
+      </Experiments>
     </Analytics.Provider>
   )
 }
 
-function ExperimentExposure({ assignments }) {
+// Wrapping the app is required: a self-closing <WeaverseExperiments /> provides
+// its context to no descendants, so useExperiment(...) under the Outlet would
+// read the empty default. Attach onExpose only once consent is granted —
+// otherwise the provider marks a variant exposed before canTrack() is true and
+// a later consent grant never re-publishes the impression.
+function Experiments({
+  assignments,
+  children,
+}: {
+  assignments: Assignment[]
+  children: ReactNode
+}) {
   let { publish, canTrack } = useAnalytics()
+  let tracking = canTrack()
   return (
     <WeaverseExperiments
       value={assignments}
-      onExpose={(a) => {
-        if (!canTrack()) return // respect Customer Privacy consent
-        publish('custom_experiment_viewed', {
-          experimentId: a.experimentId,
-          variantId: a.variant.id,
-        })
-      }}
-    />
+      onExpose={
+        tracking
+          ? (a) => {
+              publish('custom_experiment_viewed', {
+                experimentId: a.experimentId,
+                variantId: a.variant.id,
+              })
+            }
+          : undefined
+      }
+    >
+      {children}
+    </WeaverseExperiments>
   )
 }
 ```

--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -199,6 +199,21 @@ resolveExperiments([experiment], stableSeed('visitor', '123'))
   without changing visitor seeds.
 - **`projectId`** on a variant maps the experiment to a Weaverse project.
 
+## Previewing variants in Weaverse Studio
+
+Each variant is a separate Weaverse project, so you preview a variant by **opening
+its project in Weaverse Studio** — just like editing any project. Studio drives the
+storefront preview with that project pinned via the `weaverseProjectId` query param
+(priority-1 in the Hydrogen SDK's project resolver).
+
+`getExperiments` handles this automatically: when `weaverseProjectId` is present it
+**defers to Studio** — it returns that project as `projectId` (so
+`loadPage({ projectId })` loads exactly what you opened) and forces the matching
+variant's assignment (so `useExperiment(...)` and analytics `customData` reflect the
+previewed variant). No seed cookie is minted during a preview. Without this, the
+hashed assignment would override `loadPage` and pin the editor to a single bucket —
+you could never reach the other variant from Studio.
+
 ## Framework-agnostic usage
 
 `getExperiments` takes a standard `Request` and returns standard `Headers`, so the

--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -1,0 +1,248 @@
+# `@weaverse/experiments`
+
+Framework-agnostic A/B testing and experimentation for Weaverse. Opt-in: install
+it only when you run experiments — it adds nothing to storefronts that don't.
+
+- **Deterministic & storage-free** — the same visitor always lands in the same
+  variant by hashing a stable seed. No per-experiment cookies, no flicker.
+- **Framework-agnostic** — the engine and the request adapter use only web
+  standards (`Request`, `Headers`, `crypto`). Works on Shopify Oxygen/Hydrogen,
+  Cloudflare Workers, Next.js, Remix, Deno, and Bun.
+- **No vendor lock-in** — exposure events are forwarded to *your* analytics
+  (GA4, Segment, …). Nothing is bundled.
+- **Project-level by design** — a variant maps to a Weaverse `projectId`, so an
+  experiment swaps an entire theme/content project via the same multi-project
+  primitive you already use.
+
+## Install
+
+```bash
+npm i @weaverse/experiments
+```
+
+## Entry points
+
+| Import | Deps | Use |
+|---|---|---|
+| `@weaverse/experiments` | none | Engine: `assignVariant`, `resolveExperiments`, `stableSeed`, `hashToBucket` |
+| `@weaverse/experiments/server` | none | `getExperiments(request, config)` — resolve a request to assignments + a `projectId` |
+| `@weaverse/experiments/react` | `react` (optional peer) | `<WeaverseExperiments>`, `useExperiment`, `useExperiments` |
+
+The agnostic entry pulls **zero** dependencies; `react` loads only if you import
+`/react`.
+
+## Quick start (Shopify Hydrogen)
+
+**1. Resolve the experiment server-side and feed the chosen project to the client.**
+
+```ts
+// app/lib/weaverse/weaverse.server.ts
+import { getExperiments } from '@weaverse/experiments/server'
+import { WeaverseClient } from '@weaverse/hydrogen'
+
+export function createWeaverseClient(args) {
+  let { hydrogenContext, request, cache, themeSchema, components } = args
+
+  let { projectId, assignments, headers } = getExperiments(request, {
+    experiments: [
+      {
+        id: 'green-theme-test',
+        variants: [
+          { id: 'control', projectId: args.env.WEAVERSE_PROJECT_CONTROL },
+          { id: 'b', weight: 0.2, projectId: args.env.WEAVERSE_PROJECT_VARIANT_B },
+        ],
+      },
+    ],
+  })
+
+  let weaverse = new WeaverseClient({
+    ...hydrogenContext,
+    request,
+    cache,
+    themeSchema,
+    components,
+    projectId, // winning variant's project
+  })
+
+  // `headers` carries a `Set-Cookie` only when a new visitor seed is minted —
+  // merge it into your response, and pass `assignments` to the client.
+  return { weaverse, assignments, headers }
+}
+```
+
+**2. Provide assignments to React and forward exposure to analytics.**
+
+```tsx
+// app/root.tsx
+import { WeaverseExperiments } from '@weaverse/experiments/react'
+
+export default function App() {
+  let { assignments } = useLoaderData<typeof loader>()
+  return (
+    <WeaverseExperiments
+      value={assignments}
+      onExpose={(a) =>
+        window.gtag?.('event', 'experiment_view', {
+          experiment_id: a.experimentId,
+          variant_id: a.variant.id,
+        })
+      }
+    >
+      <Outlet />
+    </WeaverseExperiments>
+  )
+}
+```
+
+`onExpose` fires once per `(experiment, variant)` — wire it to any analytics
+provider. Read the active variant anywhere with `useExperiment('green-theme-test')`.
+
+## Analytics integration (Hydrogen)
+
+For Hydrogen, integrate with [`Analytics.Provider`](https://shopify.dev/docs/api/hydrogen/hooks/useanalytics)
+at two seams:
+
+1. **Segment every event by variant** — pass assignments to `customData` so
+   `page_viewed`, `product_added_to_cart`, `purchase`, … all carry the variant.
+   That's how you measure conversion *impact*, not just impressions.
+2. **Fire an exposure event** — forward `onExpose` to
+   `useAnalytics().publish('custom_experiment_viewed', …)`, gated on consent via
+   `canTrack()`.
+
+```tsx
+// app/root.tsx
+import { Analytics, useAnalytics } from '@shopify/hydrogen'
+import { WeaverseExperiments } from '@weaverse/experiments/react'
+
+export default function App() {
+  let { assignments, cart, shop, consent } = useLoaderData<typeof loader>()
+  return (
+    <Analytics.Provider
+      cart={cart}
+      shop={shop}
+      consent={consent}
+      customData={{
+        experiments: Object.fromEntries(
+          assignments.map((a) => [a.experimentId, a.variant.id])
+        ),
+      }}
+    >
+      <ExperimentExposure assignments={assignments} />
+      <Outlet />
+    </Analytics.Provider>
+  )
+}
+
+function ExperimentExposure({ assignments }) {
+  let { publish, canTrack } = useAnalytics()
+  return (
+    <WeaverseExperiments
+      value={assignments}
+      onExpose={(a) => {
+        if (!canTrack()) return // respect Customer Privacy consent
+        publish('custom_experiment_viewed', {
+          experimentId: a.experimentId,
+          variantId: a.variant.id,
+        })
+      }}
+    />
+  )
+}
+```
+
+Bridge the custom event to GA4/GTM (or any sink) from a subscriber. Custom event
+names must be prefixed `custom_`; call `ready()` so events aren't dropped before
+the subscriber attaches:
+
+```tsx
+// app/components/CustomAnalytics.tsx
+import { useAnalytics } from '@shopify/hydrogen'
+import { useEffect } from 'react'
+
+export function CustomAnalytics() {
+  let { subscribe, register } = useAnalytics()
+  let { ready } = register('CustomAnalytics')
+  useEffect(() => {
+    subscribe('custom_experiment_viewed', (data) => {
+      window.dataLayer?.push({ event: 'experiment_viewed', ...data })
+    })
+    ready()
+  }, [])
+  return null
+}
+```
+
+## How assignment works
+
+`assignVariant(experiment, seed)` hashes `"<id>:<salt>:<seed>"` with FNV-1a into a
+bucket in `[0, 1)`, then picks a variant by cumulative weight. Because it's a pure
+function of the seed, assignment is **sticky without persistence** — you only store
+a stable visitor id once (the `_wv_vid` cookie minted by `getExperiments`, or any
+id you supply via `config.seed`, e.g. a logged-in customer id or Shopify visitor
+token). Adding more experiments needs no new storage.
+
+```ts
+import { assignVariant, resolveExperiments, stableSeed } from '@weaverse/experiments'
+
+let experiment = {
+  id: 'cta-color',
+  variants: [{ id: 'control', weight: 1 }, { id: 'b', weight: 1 }],
+}
+
+assignVariant(experiment, 'visitor-123').variant.id // stable for that visitor
+resolveExperiments([experiment], stableSeed('visitor', '123'))
+```
+
+- **Weights** are relative; omitted ⇒ `1` (equal split). Non-positive ⇒ `0`
+  (never assigned).
+- **Salt** (`experiment.seed`) re-randomizes a fresh run of the same experiment id
+  without changing visitor seeds.
+- **`projectId`** on a variant maps the experiment to a Weaverse project.
+
+## Framework-agnostic usage
+
+`getExperiments` takes a standard `Request` and returns standard `Headers`, so the
+exact same call works outside Hydrogen:
+
+```ts
+// Cloudflare Worker / Next.js route handler / Remix / Deno / Bun
+import { getExperiments } from '@weaverse/experiments/server'
+
+export default {
+  fetch(request: Request) {
+    let { projectId, setCookie } = getExperiments(request, {
+      experiments: [{ id: 't', variants: [{ id: 'a', projectId: 'p1' }, { id: 'b', projectId: 'p2' }] }],
+    })
+    let res = new Response(`project=${projectId}`)
+    if (setCookie) res.headers.append('Set-Cookie', setCookie)
+    return res
+  },
+}
+```
+
+## API
+
+### `@weaverse/experiments`
+
+- `assignVariant(experiment, seed): Assignment` — deterministic, weighted pick. Throws on empty variants.
+- `resolveExperiments(experiments, seed): Assignment[]` — one assignment per experiment.
+- `stableSeed(...parts): string` — join non-empty parts into a seed.
+- `hashToBucket(key): number` — FNV-1a hash to `[0, 1)`.
+
+### `@weaverse/experiments/server`
+
+- `getExperiments(request, config): { assignments, seed, projectId?, setCookie?, headers }`
+  - `config.experiments` — experiments to resolve.
+  - `config.projectIdFrom` — which experiment supplies `projectId` (default: first).
+  - `config.seed` — supply a seed to skip cookie handling.
+  - `config.cookieName` / `config.maxAge` — seed cookie tuning (default `_wv_vid`, 1 year).
+
+### `@weaverse/experiments/react`
+
+- `<WeaverseExperiments value={assignments} onExpose?={fn}>` — provides assignments, fires exposure once per `(experiment, variant)`.
+- `useExperiment(id): Assignment | undefined`
+- `useExperiments(): Assignment[]`
+
+## License
+
+MIT

--- a/packages/experiments/__tests__/engine.test.ts
+++ b/packages/experiments/__tests__/engine.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+import type { Experiment } from '../src/index'
+import {
+  assignVariant,
+  hashToBucket,
+  resolveExperiments,
+  stableSeed,
+} from '../src/index'
+
+let TWO_WAY: Experiment = {
+  id: 'homepage-test',
+  variants: [{ id: 'control' }, { id: 'b' }],
+}
+
+// Deterministic spread of distinct seeds for distribution assertions.
+function sampleSeeds(count: number): string[] {
+  let seeds: string[] = []
+  for (let i = 0; i < count; i++) {
+    seeds.push(stableSeed('visitor', String(i)))
+  }
+  return seeds
+}
+
+function distribution(
+  exp: Experiment,
+  seeds: string[]
+): Record<string, number> {
+  let counts: Record<string, number> = {}
+  for (let seed of seeds) {
+    let id = assignVariant(exp, seed).variant.id
+    counts[id] = (counts[id] ?? 0) + 1
+  }
+  return counts
+}
+
+describe('hashToBucket', () => {
+  it('should_return_value_in_unit_interval_when_hashing_any_string', () => {
+    for (let s of sampleSeeds(500)) {
+      let bucket = hashToBucket(s)
+
+      expect(bucket).toBeGreaterThanOrEqual(0)
+      expect(bucket).toBeLessThan(1)
+    }
+  })
+
+  it('should_return_same_bucket_when_called_repeatedly_with_same_key', () => {
+    let first = hashToBucket('user-42:homepage-test')
+    let second = hashToBucket('user-42:homepage-test')
+
+    expect(second).toBe(first)
+  })
+})
+
+describe('assignVariant', () => {
+  it('should_return_same_variant_when_called_repeatedly_with_same_seed', () => {
+    let seed = stableSeed('visitor', 'abc-123')
+
+    let first = assignVariant(TWO_WAY, seed)
+    let second = assignVariant(TWO_WAY, seed)
+
+    expect(second.variant.id).toBe(first.variant.id)
+    expect(first.experimentId).toBe('homepage-test')
+  })
+
+  it('should_split_traffic_evenly_when_weights_are_omitted', () => {
+    let counts = distribution(TWO_WAY, sampleSeeds(10_000))
+
+    expect(counts.control / 10_000).toBeGreaterThan(0.45)
+    expect(counts.control / 10_000).toBeLessThan(0.55)
+  })
+
+  it('should_respect_relative_weights_when_provided', () => {
+    let weighted: Experiment = {
+      id: 'weighted-test',
+      variants: [
+        { id: 'control', weight: 4 },
+        { id: 'b', weight: 1 },
+      ],
+    }
+
+    let counts = distribution(weighted, sampleSeeds(10_000))
+
+    expect(counts.b / 10_000).toBeGreaterThan(0.15)
+    expect(counts.b / 10_000).toBeLessThan(0.25)
+  })
+
+  it('should_always_return_the_only_variant_when_experiment_has_one', () => {
+    let single: Experiment = { id: 'rollout', variants: [{ id: 'on' }] }
+
+    for (let seed of sampleSeeds(200)) {
+      expect(assignVariant(single, seed).variant.id).toBe('on')
+    }
+  })
+
+  it('should_change_assignment_when_experiment_seed_salt_differs', () => {
+    let seeds = sampleSeeds(300)
+    let salted: Experiment = { ...TWO_WAY, seed: 'rerun-2' }
+
+    let baseVector = seeds.map((s) => assignVariant(TWO_WAY, s).variant.id)
+    let saltedVector = seeds.map((s) => assignVariant(salted, s).variant.id)
+
+    expect(saltedVector).not.toEqual(baseVector)
+  })
+
+  it('should_carry_variant_projectId_through_to_the_assignment', () => {
+    let projectMapped: Experiment = {
+      id: 'theme-test',
+      variants: [
+        { id: 'control', projectId: 'proj-a' },
+        { id: 'b', projectId: 'proj-b' },
+      ],
+    }
+
+    let assigned = assignVariant(projectMapped, stableSeed('v', '7'))
+
+    expect(assigned.variant.projectId).toMatch(/^proj-(a|b)$/)
+  })
+
+  it('should_throw_when_experiment_has_no_variants', () => {
+    let empty: Experiment = { id: 'broken', variants: [] }
+
+    expect(() => assignVariant(empty, 'seed')).toThrow(/variant/i)
+  })
+
+  it('should_ignore_non_positive_weights_when_splitting', () => {
+    let zeroed: Experiment = {
+      id: 'zero-weight',
+      variants: [
+        { id: 'control', weight: 0 },
+        { id: 'b', weight: 1 },
+      ],
+    }
+
+    let counts = distribution(zeroed, sampleSeeds(2000))
+
+    expect(counts.control ?? 0).toBe(0)
+    expect(counts.b).toBe(2000)
+  })
+})
+
+describe('resolveExperiments', () => {
+  it('should_return_one_independent_assignment_per_experiment', () => {
+    let experiments: Experiment[] = [
+      TWO_WAY,
+      { id: 'cta-test', variants: [{ id: 'green' }, { id: 'red' }] },
+    ]
+    let seed = stableSeed('visitor', 'multi')
+
+    let assignments = resolveExperiments(experiments, seed)
+
+    expect(assignments.map((a) => a.experimentId)).toEqual([
+      'homepage-test',
+      'cta-test',
+    ])
+  })
+
+  it('should_assign_experiments_independently_for_same_seed', () => {
+    // Two experiments with identical variant ids must not always collapse to
+    // the same choice — the experiment id participates in the hash key.
+    let a: Experiment = { id: 'exp-a', variants: [{ id: 'x' }, { id: 'y' }] }
+    let b: Experiment = { id: 'exp-b', variants: [{ id: 'x' }, { id: 'y' }] }
+
+    let differ = sampleSeeds(300).some((seed) => {
+      let [ra] = resolveExperiments([a], seed)
+      let [rb] = resolveExperiments([b], seed)
+      return ra.variant.id !== rb.variant.id
+    })
+
+    expect(differ).toBe(true)
+  })
+})
+
+describe('stableSeed', () => {
+  it('should_produce_same_seed_when_nullish_parts_are_dropped', () => {
+    let withGaps = stableSeed('a', null, 'b', undefined)
+    let without = stableSeed('a', 'b')
+
+    expect(withGaps).toBe(without)
+  })
+
+  it('should_return_non_empty_string_for_at_least_one_part', () => {
+    expect(stableSeed('visitor-1').length).toBeGreaterThan(0)
+  })
+})

--- a/packages/experiments/__tests__/exposure.test.ts
+++ b/packages/experiments/__tests__/exposure.test.ts
@@ -49,4 +49,23 @@ describe('createExposureTracker', () => {
 
     expect(onExpose).toHaveBeenCalledTimes(2)
   })
+
+  it('should_re_expose_when_the_sink_throws_instead_of_marking_seen', () => {
+    let tracker = createExposureTracker()
+    let calls = 0
+    let flaky = () => {
+      calls += 1
+      if (calls === 1) {
+        throw new Error('sink down')
+      }
+    }
+    let assignments = [assignment('a', 'control')]
+
+    // First emit throws before the pair is marked seen…
+    expect(() => tracker.expose(assignments, flaky)).toThrow('sink down')
+    // …so a later call re-exposes it instead of dropping the event.
+    tracker.expose(assignments, flaky)
+
+    expect(calls).toBe(2)
+  })
 })

--- a/packages/experiments/__tests__/exposure.test.ts
+++ b/packages/experiments/__tests__/exposure.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Assignment } from '../src/index'
+import { createExposureTracker } from '../src/react'
+
+function assignment(experimentId: string, variantId: string): Assignment {
+  return { experimentId, variant: { id: variantId } }
+}
+
+describe('createExposureTracker', () => {
+  it('should_fire_onExpose_once_per_assignment_on_first_call', () => {
+    let onExpose = vi.fn()
+    let tracker = createExposureTracker()
+
+    tracker.expose([assignment('a', 'control'), assignment('b', 'x')], onExpose)
+
+    expect(onExpose).toHaveBeenCalledTimes(2)
+  })
+
+  it('should_not_refire_for_an_already_exposed_pair', () => {
+    let onExpose = vi.fn()
+    let tracker = createExposureTracker()
+    let assignments = [assignment('a', 'control')]
+
+    tracker.expose(assignments, onExpose)
+    tracker.expose(assignments, onExpose)
+
+    expect(onExpose).toHaveBeenCalledTimes(1)
+  })
+
+  it('should_refire_when_the_variant_changes_for_the_same_experiment', () => {
+    let onExpose = vi.fn()
+    let tracker = createExposureTracker()
+
+    tracker.expose([assignment('a', 'control')], onExpose)
+    tracker.expose([assignment('a', 'b')], onExpose)
+
+    expect(onExpose).toHaveBeenCalledTimes(2)
+    expect(onExpose).toHaveBeenLastCalledWith(assignment('a', 'b'))
+  })
+
+  it('should_isolate_dedupe_state_between_separate_trackers', () => {
+    let onExpose = vi.fn()
+    let first = createExposureTracker()
+    let second = createExposureTracker()
+    let assignments = [assignment('a', 'control')]
+
+    first.expose(assignments, onExpose)
+    second.expose(assignments, onExpose)
+
+    expect(onExpose).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/experiments/__tests__/server.test.ts
+++ b/packages/experiments/__tests__/server.test.ts
@@ -134,3 +134,88 @@ describe('getExperiments', () => {
     expect(result.setCookie).toContain('_wv_vid=')
   })
 })
+
+describe('getExperiments — Weaverse Studio preview', () => {
+  function studioRequest(previewProjectId: string, cookie?: string): Request {
+    let url = `https://shop.example/?weaverseProjectId=${previewProjectId}&isDesignMode=true`
+    return new Request(url, { headers: cookie ? { cookie } : {} })
+  }
+
+  it('should_pin_the_previewed_project_over_the_hashed_assignment', () => {
+    // Same sticky visitor, both preview directions: the seed can only hash to
+    // one variant, so at least one of these is a real override — both returning
+    // the pinned variant proves Studio wins over the hash.
+    let toB = getExperiments(studioRequest('proj-b', '_wv_vid=sticky-user'), {
+      experiments: [THEME_TEST],
+    })
+    let toControl = getExperiments(
+      studioRequest('proj-control', '_wv_vid=sticky-user'),
+      { experiments: [THEME_TEST] }
+    )
+
+    expect(toB.projectId).toBe('proj-b')
+    expect(toB.assignments[0].variant.id).toBe('b')
+    expect(toControl.projectId).toBe('proj-control')
+    expect(toControl.assignments[0].variant.id).toBe('control')
+  })
+
+  it('should_not_persist_a_seed_cookie_during_a_preview', () => {
+    let result = getExperiments(studioRequest('proj-b'), {
+      experiments: [THEME_TEST],
+    })
+
+    expect(result.setCookie).toBeUndefined()
+    expect(result.headers.get('Set-Cookie')).toBeNull()
+  })
+
+  it('should_only_force_the_experiment_that_owns_the_previewed_project', () => {
+    let layout: Experiment = {
+      id: 'layout-test',
+      variants: [{ id: 'a' }, { id: 'b' }],
+    }
+    let preview = getExperiments(
+      studioRequest('proj-b', '_wv_vid=sticky-user'),
+      {
+        experiments: [layout, THEME_TEST],
+      }
+    )
+    let live = getExperiments(requestWithCookie('_wv_vid=sticky-user'), {
+      experiments: [layout, THEME_TEST],
+    })
+
+    let themePreview = preview.assignments.find(
+      (a) => a.experimentId === 'theme-test'
+    )
+    expect(themePreview?.variant.id).toBe('b')
+    // The unrelated experiment keeps its normal hashed assignment.
+    let layoutPreview = preview.assignments.find(
+      (a) => a.experimentId === 'layout-test'
+    )
+    let layoutLive = live.assignments.find(
+      (a) => a.experimentId === 'layout-test'
+    )
+    expect(layoutPreview?.variant.id).toBe(layoutLive?.variant.id)
+  })
+
+  it('should_defer_to_studio_for_a_project_outside_any_experiment', () => {
+    // Previewing the default project (no matching variant): no variant forced,
+    // but the override still steps aside so the SDK loads Studio's project.
+    let result = getExperiments(
+      studioRequest('proj-default', '_wv_vid=sticky-user'),
+      { experiments: [THEME_TEST] }
+    )
+
+    expect(result.projectId).toBe('proj-default')
+  })
+
+  it('should_keep_the_last_weaverseProjectId_when_the_key_is_duplicated', () => {
+    // getRequestQueries keeps the LAST value of a duplicated key; match it so
+    // the pin agrees with the SDK's projectId resolver.
+    let url =
+      'https://shop.example/?weaverseProjectId=proj-control&weaverseProjectId=proj-b'
+    let result = getExperiments(new Request(url), { experiments: [THEME_TEST] })
+
+    expect(result.projectId).toBe('proj-b')
+    expect(result.assignments[0].variant.id).toBe('b')
+  })
+})

--- a/packages/experiments/__tests__/server.test.ts
+++ b/packages/experiments/__tests__/server.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+import type { Experiment } from '../src/index'
+import { assignVariant } from '../src/index'
+import { getExperiments } from '../src/server'
+
+let THEME_TEST: Experiment = {
+  id: 'theme-test',
+  variants: [
+    { id: 'control', projectId: 'proj-control' },
+    { id: 'b', projectId: 'proj-b' },
+  ],
+}
+
+function requestWithCookie(cookie?: string): Request {
+  return new Request('https://shop.example/', {
+    headers: cookie ? { cookie } : {},
+  })
+}
+
+describe('getExperiments', () => {
+  it('should_mint_a_seed_cookie_when_request_has_none', () => {
+    let result = getExperiments(requestWithCookie(), {
+      experiments: [THEME_TEST],
+    })
+
+    expect(result.setCookie).toBeDefined()
+    expect(result.setCookie).toContain('_wv_vid=')
+    expect(result.headers.get('Set-Cookie')).toBe(result.setCookie)
+  })
+
+  it('should_mark_the_seed_cookie_http_only_and_persistent', () => {
+    let result = getExperiments(requestWithCookie(), {
+      experiments: [THEME_TEST],
+    })
+
+    expect(result.setCookie).toContain('HttpOnly')
+    expect(result.setCookie).toContain('Max-Age=')
+    expect(result.setCookie).toContain('SameSite=Lax')
+  })
+
+  it('should_reuse_existing_seed_cookie_without_minting_a_new_one', () => {
+    let result = getExperiments(requestWithCookie('_wv_vid=visitor-123'), {
+      experiments: [THEME_TEST],
+    })
+
+    expect(result.setCookie).toBeUndefined()
+    expect(result.seed).toBe('visitor-123')
+    expect(result.headers.get('Set-Cookie')).toBeNull()
+  })
+
+  it('should_match_engine_assignment_for_the_resolved_seed', () => {
+    let result = getExperiments(requestWithCookie('_wv_vid=visitor-123'), {
+      experiments: [THEME_TEST],
+    })
+
+    let expected = assignVariant(THEME_TEST, 'visitor-123')
+    expect(result.assignments[0].variant.id).toBe(expected.variant.id)
+  })
+
+  it('should_keep_the_same_visitor_in_the_same_variant_across_requests', () => {
+    let cookie = '_wv_vid=sticky-user'
+
+    let first = getExperiments(requestWithCookie(cookie), {
+      experiments: [THEME_TEST],
+    })
+    let second = getExperiments(requestWithCookie(cookie), {
+      experiments: [THEME_TEST],
+    })
+
+    expect(second.assignments[0].variant.id).toBe(
+      first.assignments[0].variant.id
+    )
+  })
+
+  it('should_use_a_supplied_seed_without_touching_cookies', () => {
+    let result = getExperiments(requestWithCookie('_wv_vid=ignored'), {
+      experiments: [THEME_TEST],
+      seed: 'customer-42',
+    })
+
+    expect(result.seed).toBe('customer-42')
+    expect(result.setCookie).toBeUndefined()
+    expect(result.assignments[0].variant.id).toBe(
+      assignVariant(THEME_TEST, 'customer-42').variant.id
+    )
+  })
+
+  it('should_map_chosen_variant_to_its_projectId', () => {
+    let result = getExperiments(requestWithCookie('_wv_vid=sticky-user'), {
+      experiments: [THEME_TEST],
+    })
+
+    let chosen = result.assignments[0].variant
+    expect(result.projectId).toBe(chosen.projectId)
+  })
+
+  it('should_take_projectId_from_the_designated_experiment', () => {
+    let layout: Experiment = {
+      id: 'layout-test',
+      variants: [{ id: 'a' }, { id: 'b' }],
+    }
+
+    let result = getExperiments(requestWithCookie('_wv_vid=sticky-user'), {
+      experiments: [layout, THEME_TEST],
+      projectIdFrom: 'theme-test',
+    })
+
+    let themeAssignment = result.assignments.find(
+      (a) => a.experimentId === 'theme-test'
+    )
+    expect(result.projectId).toBe(themeAssignment?.variant.projectId)
+    expect(result.projectId).toMatch(/^proj-(control|b)$/)
+  })
+
+  it('should_honor_a_custom_cookie_name', () => {
+    let result = getExperiments(requestWithCookie(), {
+      experiments: [THEME_TEST],
+      cookieName: '_exp_id',
+    })
+
+    expect(result.setCookie).toContain('_exp_id=')
+  })
+
+  it('should_mint_a_fresh_seed_when_cookie_has_malformed_encoding', () => {
+    // A client-controlled cookie with invalid percent-encoding must not crash
+    // the request: decodeURIComponent('%') throws, so it's treated as absent.
+    let run = () =>
+      getExperiments(requestWithCookie('_wv_vid=%'), {
+        experiments: [THEME_TEST],
+      })
+
+    expect(run).not.toThrow()
+    let result = run()
+    expect(result.setCookie).toContain('_wv_vid=')
+  })
+})

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@weaverse/experiments",
+  "version": "0.1.0",
+  "description": "Framework-agnostic A/B testing and experimentation for Weaverse — deterministic, storage-free variant assignment",
+  "author": "Weaverse",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Weaverse/weaverse.git",
+    "directory": "packages/experiments"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@weaverse:registry": "https://registry.npmjs.org"
+  },
+  "files": [
+    "dist/*"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js",
+      "require": "./dist/server.cjs"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/react.cjs"
+    }
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "dev": "tsup --watch",
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "test": "vp test --run",
+    "typecheck": "tsc --noEmit"
+  },
+  "tsup": {
+    "entry": [
+      "src/index.ts",
+      "src/server.ts",
+      "src/react.tsx"
+    ],
+    "format": [
+      "esm",
+      "cjs"
+    ],
+    "dts": true,
+    "sourcemap": true,
+    "clean": true,
+    "outDir": "dist",
+    "treeshake": true
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.13"
+  }
+}

--- a/packages/experiments/src/index.ts
+++ b/packages/experiments/src/index.ts
@@ -1,0 +1,131 @@
+/**
+ * `@weaverse/experiments` — framework-agnostic experimentation engine.
+ *
+ * Variant assignment is **deterministic**: a stable visitor seed is hashed
+ * together with the experiment id, so the same visitor always lands in the
+ * same variant without storing the assignment anywhere. Adding more
+ * experiments costs no extra storage — only a stable seed (see `/server`).
+ *
+ * This module has zero dependencies and zero runtime globals; it runs in any
+ * JavaScript environment (Node, browsers, Cloudflare Workers, Deno, Bun).
+ */
+
+export interface ExperimentVariant {
+  /** Stable identifier for the variant, e.g. `'control'` or `'b'`. */
+  id: string
+  /**
+   * Weaverse project to load for this variant. Lets a single experiment drive
+   * project-level A/B testing (the variant maps straight to a `projectId`).
+   */
+  projectId?: string
+  /**
+   * Relative traffic weight. Omitted variants default to `1` (equal split).
+   * Non-positive weights are clamped to `0` (variant never assigned).
+   */
+  weight?: number
+}
+
+export interface Experiment {
+  /** Stable identifier, also mixed into the hash so experiments are independent. */
+  id: string
+  /**
+   * Optional salt. Change it to re-randomize assignments for a fresh run of
+   * the same experiment id without changing visitor seeds.
+   */
+  seed?: string
+  /** At least one variant. Throws on assignment when empty. */
+  variants: ExperimentVariant[]
+}
+
+export interface Assignment {
+  experimentId: string
+  variant: ExperimentVariant
+}
+
+// FNV-1a 32-bit: tiny, fast, well-distributed, dependency-free.
+const FNV_OFFSET_BASIS = 0x81_1c_9d_c5
+const FNV_PRIME = 0x01_00_01_93
+// 2^32 — dividing by it keeps the result strictly within [0, 1).
+const UINT32_RANGE = 0x1_00_00_00_00
+
+/**
+ * Hashes a key to a uniformly-distributed bucket in the half-open unit
+ * interval `[0, 1)`. Pure and deterministic: same key → same bucket.
+ */
+export function hashToBucket(key: string): number {
+  let hash = FNV_OFFSET_BASIS
+  for (let i = 0; i < key.length; i += 1) {
+    // biome-ignore lint/suspicious/noBitwiseOperators: FNV-1a hashing is defined in terms of XOR
+    hash ^= key.charCodeAt(i)
+    hash = Math.imul(hash, FNV_PRIME)
+  }
+  // biome-ignore lint/suspicious/noBitwiseOperators: coerce signed Math.imul result to a uint32 before normalising
+  return (hash >>> 0) / UINT32_RANGE
+}
+
+/**
+ * Deterministically assigns a `seed` (typically a stable visitor id) to one of
+ * the experiment's variants, weighted by `weight`. The experiment id and
+ * optional `seed` salt are folded into the hash key so experiments are
+ * mutually independent and re-runnable.
+ *
+ * @throws if the experiment has no variants.
+ */
+export function assignVariant(
+  experiment: Experiment,
+  seed: string
+): Assignment {
+  let { id, variants, seed: salt } = experiment
+  if (!variants || variants.length === 0) {
+    throw new Error(`Weaverse experiment "${id}" has no variants to assign.`)
+  }
+
+  // Omitted weight defaults to 1; provided non-positive weights clamp to 0.
+  let total = 0
+  for (let variant of variants) {
+    total += Math.max(0, variant.weight ?? 1)
+  }
+
+  // All-zero weights: nothing to weight by — fall back to the first variant.
+  let chosen = total > 0 ? variants[variants.length - 1] : variants[0]
+
+  if (total > 0) {
+    let threshold = hashToBucket(`${id}:${salt ?? ''}:${seed}`) * total
+    let cumulative = 0
+    for (let variant of variants) {
+      cumulative += Math.max(0, variant.weight ?? 1)
+      if (threshold < cumulative) {
+        chosen = variant
+        break
+      }
+    }
+  }
+
+  return { experimentId: id, variant: chosen }
+}
+
+/**
+ * Resolves a batch of experiments for a single seed, returning one assignment
+ * per experiment in input order.
+ */
+export function resolveExperiments(
+  experiments: Experiment[],
+  seed: string
+): Assignment[] {
+  return experiments.map((experiment) => assignVariant(experiment, seed))
+}
+
+/**
+ * Builds a stable seed string from parts, dropping nullish and empty values.
+ * Use it to compose a visitor identity from whatever signals are available
+ * (first-party id, Shopify visitor token, etc.).
+ */
+export function stableSeed(...parts: Array<string | null | undefined>): string {
+  let kept: string[] = []
+  for (let part of parts) {
+    if (part !== null && part !== undefined && part !== '') {
+      kept.push(part)
+    }
+  }
+  return kept.join(':')
+}

--- a/packages/experiments/src/react.tsx
+++ b/packages/experiments/src/react.tsx
@@ -1,0 +1,100 @@
+/**
+ * `@weaverse/experiments/react` — optional React bindings.
+ *
+ * `react` is an optional peer dependency: importing this entry is the only
+ * thing that pulls React in. The agnostic engine (`@weaverse/experiments`) and
+ * the request adapter (`@weaverse/experiments/server`) stay React-free.
+ */
+
+import type { ReactNode } from 'react'
+import { createContext, useContext, useEffect, useRef } from 'react'
+import type { Assignment } from './index'
+
+export interface ExposureTracker {
+  /**
+   * Invokes `onExpose` once per `(experimentId, variant.id)` pair across the
+   * tracker's lifetime; pairs seen on a previous call are skipped.
+   */
+  expose(
+    assignments: Assignment[],
+    onExpose: (assignment: Assignment) => void
+  ): void
+}
+
+/**
+ * Creates a stateful exposure tracker. Kept synchronous and framework-free so
+ * the fire-once logic is unit-testable without a DOM; the React component below
+ * just drives it from an effect. Re-exposes when a variant changes for the same
+ * experiment (the variant id is part of the dedupe key).
+ */
+export function createExposureTracker(): ExposureTracker {
+  let seen = new Set<string>()
+  return {
+    expose(assignments, onExpose) {
+      for (let assignment of assignments) {
+        let key = `${assignment.experimentId}:${assignment.variant.id}`
+        if (!seen.has(key)) {
+          seen.add(key)
+          onExpose(assignment)
+        }
+      }
+    },
+  }
+}
+
+interface ExperimentsContextValue {
+  assignments: Assignment[]
+}
+
+let ExperimentsContext = createContext<ExperimentsContextValue>({
+  assignments: [],
+})
+
+export interface WeaverseExperimentsProps {
+  children?: ReactNode
+  /**
+   * Fired once per `(experiment, variant)` when first exposed on the client.
+   * Forward it to any analytics sink (GA4, Segment, etc.) — no vendor is bundled.
+   */
+  onExpose?: (assignment: Assignment) => void
+  /** Assignments resolved server-side (e.g. from `getExperiments`). */
+  value: Assignment[]
+}
+
+/**
+ * Provides resolved assignments to descendants and fires exposure events once
+ * each. Place near the root, passing the server-resolved `assignments`.
+ */
+export function WeaverseExperiments({
+  value,
+  onExpose,
+  children,
+}: WeaverseExperimentsProps) {
+  let tracker = useRef<ExposureTracker | null>(null)
+  tracker.current ??= createExposureTracker()
+
+  useEffect(() => {
+    if (onExpose) {
+      tracker.current?.expose(value, onExpose)
+    }
+  }, [value, onExpose])
+
+  return (
+    <ExperimentsContext.Provider value={{ assignments: value }}>
+      {children}
+    </ExperimentsContext.Provider>
+  )
+}
+
+/** Returns the assignment for `experimentId`, or `undefined` if not running. */
+export function useExperiment(experimentId: string): Assignment | undefined {
+  let { assignments } = useContext(ExperimentsContext)
+  return assignments.find(
+    (assignment) => assignment.experimentId === experimentId
+  )
+}
+
+/** Returns all resolved assignments from the nearest provider. */
+export function useExperiments(): Assignment[] {
+  return useContext(ExperimentsContext).assignments
+}

--- a/packages/experiments/src/react.tsx
+++ b/packages/experiments/src/react.tsx
@@ -25,7 +25,9 @@ export interface ExposureTracker {
  * Creates a stateful exposure tracker. Kept synchronous and framework-free so
  * the fire-once logic is unit-testable without a DOM; the React component below
  * just drives it from an effect. Re-exposes when a variant changes for the same
- * experiment (the variant id is part of the dedupe key).
+ * experiment (the variant id is part of the dedupe key). A pair is recorded
+ * only after `onExpose` returns, so a throwing sink re-exposes rather than
+ * dropping the event.
  */
 export function createExposureTracker(): ExposureTracker {
   let seen = new Set<string>()
@@ -34,8 +36,10 @@ export function createExposureTracker(): ExposureTracker {
       for (let assignment of assignments) {
         let key = `${assignment.experimentId}:${assignment.variant.id}`
         if (!seen.has(key)) {
-          seen.add(key)
+          // Emit first, record second: if the sink throws, the pair stays
+          // unmarked and re-exposes on the next call instead of being lost.
           onExpose(assignment)
+          seen.add(key)
         }
       }
     },

--- a/packages/experiments/src/server.ts
+++ b/packages/experiments/src/server.ts
@@ -1,0 +1,122 @@
+/**
+ * `@weaverse/experiments/server` — request adapter built on web standards
+ * (`Request`, `Headers`, `crypto.randomUUID`). No framework dependency, so it
+ * runs anywhere a Fetch-API request is available: Shopify Oxygen/Hydrogen,
+ * Cloudflare Workers, Next.js edge/route handlers, Remix, Deno, Bun.
+ *
+ * It resolves a stable visitor seed (minting a first-party cookie once if
+ * needed), assigns every configured experiment deterministically, and maps the
+ * chosen variant to a Weaverse `projectId` for project-level A/B testing.
+ */
+
+import type { Assignment, Experiment } from './index'
+import { resolveExperiments } from './index'
+
+const DEFAULT_SEED_COOKIE = '_wv_vid'
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365
+
+export interface ExperimentsServerConfig {
+  /** Cookie name used to persist the minted visitor seed. Default `_wv_vid`. */
+  cookieName?: string
+  /** Experiments to resolve for this request. */
+  experiments: Experiment[]
+  /** Lifetime of the seed cookie in seconds. Default one year. */
+  maxAge?: number
+  /**
+   * Id of the experiment whose chosen variant supplies `projectId`. Defaults
+   * to the first experiment. Use it when several experiments run at once but
+   * only one drives project selection.
+   */
+  projectIdFrom?: string
+  /**
+   * Pre-resolved seed (e.g. a logged-in customer id or an existing Shopify
+   * visitor token). When provided, no cookie is read or minted.
+   */
+  seed?: string
+}
+
+export interface ExperimentsResult {
+  /** One assignment per configured experiment, in input order. */
+  assignments: Assignment[]
+  /**
+   * Convenience `Headers` carrying `Set-Cookie` when one is needed (otherwise
+   * empty). Merge into the `Response` you return from the loader/handler.
+   */
+  headers: Headers
+  /**
+   * `projectId` from the designated experiment's chosen variant, or `undefined`
+   * when that variant declares none. Feed it to `new WeaverseClient(...)` or
+   * `weaverse.loadPage({ projectId })`.
+   */
+  projectId?: string
+  /** The stable visitor seed used to compute the assignments. */
+  seed: string
+  /**
+   * `Set-Cookie` value persisting a freshly-minted seed, or `undefined` when
+   * the seed already existed or was supplied via `config.seed`. Append it to
+   * your response headers to make assignment sticky across visits.
+   */
+  setCookie?: string
+}
+
+function readCookie(
+  cookieHeader: string | null,
+  name: string
+): string | undefined {
+  if (!cookieHeader) {
+    return
+  }
+  for (let pair of cookieHeader.split(';')) {
+    let index = pair.indexOf('=')
+    if (index === -1) {
+      continue
+    }
+    if (pair.slice(0, index).trim() === name) {
+      try {
+        return decodeURIComponent(pair.slice(index + 1).trim())
+      } catch {
+        // Malformed percent-encoding in a client-controlled cookie: treat it as
+        // absent so a fresh seed is minted instead of throwing on every request.
+        return
+      }
+    }
+  }
+  return
+}
+
+/**
+ * Resolves experiment assignments for an incoming request.
+ *
+ * Seed precedence: `config.seed` → existing `cookieName` cookie → a newly
+ * minted UUID (returned as `setCookie`/`headers` for persistence).
+ */
+export function getExperiments(
+  request: Request,
+  config: ExperimentsServerConfig
+): ExperimentsResult {
+  let { experiments, projectIdFrom, cookieName, maxAge } = config
+  let name = cookieName ?? DEFAULT_SEED_COOKIE
+  let headers = new Headers()
+
+  let seed = config.seed
+  let setCookie: string | undefined
+  if (!seed) {
+    let existing = readCookie(request.headers.get('cookie'), name)
+    if (existing) {
+      seed = existing
+    } else {
+      seed = crypto.randomUUID()
+      setCookie = `${name}=${seed}; Path=/; Max-Age=${maxAge ?? ONE_YEAR_SECONDS}; SameSite=Lax; HttpOnly; Secure`
+      headers.set('Set-Cookie', setCookie)
+    }
+  }
+
+  let assignments = resolveExperiments(experiments, seed)
+
+  let projectExperimentId = projectIdFrom ?? experiments[0]?.id
+  let projectId = assignments.find(
+    (assignment) => assignment.experimentId === projectExperimentId
+  )?.variant.projectId
+
+  return { assignments, seed, projectId, setCookie, headers }
+}

--- a/packages/experiments/src/server.ts
+++ b/packages/experiments/src/server.ts
@@ -46,7 +46,9 @@ export interface ExperimentsResult {
   /**
    * `projectId` from the designated experiment's chosen variant, or `undefined`
    * when that variant declares none. Feed it to `new WeaverseClient(...)` or
-   * `weaverse.loadPage({ projectId })`.
+   * `weaverse.loadPage({ projectId })`. During a Weaverse Studio preview
+   * (`?weaverseProjectId=…`) this is the pinned project instead, so each variant
+   * stays previewable by opening its own project in Studio.
    */
   projectId?: string
   /** The stable visitor seed used to compute the assignments. */
@@ -98,12 +100,26 @@ export function getExperiments(
   let name = cookieName ?? DEFAULT_SEED_COOKIE
   let headers = new Headers()
 
+  // Weaverse Studio drives the storefront preview with the project being edited
+  // pinned via the `weaverseProjectId` query param — priority-1 in the SDK's
+  // projectId resolver, which keeps the LAST value of the key. Each variant is
+  // its own project, so previewing a variant means opening that project in
+  // Studio. Defer to it here: otherwise the hashed assignment below would supply
+  // a `projectId` that overrides `loadPage({ projectId })` and hijack the
+  // preview, pinning the editor to whichever variant the cookie buckets into.
+  let previewProjectId = new URL(request.url).searchParams
+    .getAll('weaverseProjectId')
+    .at(-1)
+
   let seed = config.seed
   let setCookie: string | undefined
   if (!seed) {
     let existing = readCookie(request.headers.get('cookie'), name)
     if (existing) {
       seed = existing
+    } else if (previewProjectId) {
+      // Resolve deterministically for the preview without persisting a cookie.
+      seed = previewProjectId
     } else {
       seed = crypto.randomUUID()
       setCookie = `${name}=${seed}; Path=/; Max-Age=${maxAge ?? ONE_YEAR_SECONDS}; SameSite=Lax; HttpOnly; Secure`
@@ -112,6 +128,26 @@ export function getExperiments(
   }
 
   let assignments = resolveExperiments(experiments, seed)
+
+  if (previewProjectId) {
+    // Force the assignment whose variant maps to the previewed project so
+    // `useExperiment(...)` and analytics `customData` match what Studio renders.
+    assignments = assignments.map((assignment) => {
+      let previewed = experiments
+        .find((experiment) => experiment.id === assignment.experimentId)
+        ?.variants.find((variant) => variant.projectId === previewProjectId)
+      return previewed
+        ? { experimentId: assignment.experimentId, variant: previewed }
+        : assignment
+    })
+    return {
+      assignments,
+      seed,
+      projectId: previewProjectId,
+      setCookie,
+      headers,
+    }
+  }
 
   let projectExperimentId = projectIdFrom ?? experiments[0]?.id
   let projectId = assignments.find(

--- a/packages/experiments/tsconfig.json
+++ b/packages/experiments/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    },
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,16 @@ importers:
 
   packages/core: {}
 
+  packages/experiments:
+    dependencies:
+      react:
+        specifier: '>=18'
+        version: 19.2.4
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.13
+        version: 19.2.14
+
   packages/hydrogen:
     dependencies:
       '@shopify/hydrogen':


### PR DESCRIPTION
## Summary

New **opt-in** package `@weaverse/experiments` for project-level A/B testing on Weaverse storefronts. Replaces the ~80-line manual cookie recipe in the multi-project guide with a deterministic, framework-agnostic helper. Install it only when you run experiments — it adds nothing to storefronts that don't.

## Design

- **Deterministic & storage-free** — FNV-1a hash of a stable visitor seed → the same visitor always lands in the same variant, with no per-experiment cookie and no flicker.
- **Project-level** — a variant maps to a Weaverse `projectId`, reusing the multi-project primitive (one experiment swaps an entire theme/content project).
- **Framework-agnostic** — engine + `/server` use only web standards (`Request`, `Headers`, `crypto`); runs on Hydrogen, Cloudflare Workers, Next.js, Remix, Deno, Bun.
- **No vendor lock-in** — exposure events forward to *your* analytics; nothing bundled.

### Entry points

| Import | Deps | Purpose |
|---|---|---|
| `@weaverse/experiments` | none | Engine: `assignVariant`, `resolveExperiments`, `stableSeed`, `hashToBucket` |
| `@weaverse/experiments/server` | none | `getExperiments(request, config)` → `{ assignments, projectId, headers }`, mints `_wv_vid` |
| `@weaverse/experiments/react` | `react` (optional peer) | `<WeaverseExperiments>`, `useExperiment(s)`, fire-once exposure |

### Hydrogen analytics

Documented in the README: pass assignments to `<Analytics.Provider customData>` to segment every event by variant, and `useAnalytics().publish('custom_experiment_viewed', …)` (gated on `canTrack()`) for impressions.

## Verification

- `tsc --noEmit`: **0 errors**
- **27/27 unit tests** (engine · server · exposure)
- tsup build OK (ESM + CJS + dts, `react` external)
- ESM + CJS + `/react` import smoke all pass (deterministic assignment, CJS require, server cookie + `projectId`, fire-once exposure)

## Docs

- `AGENTS.md` and `ARCHITECTURE.md` updated to list the package.
- The multi-project guide A/B section (docs repo) and the `weaverse-hydrogen` / `hydrogen-analytics-tracking` skills are updated in their own repos (separate PRs).

## Notes / follow-ups

- Independent (FREE) version group, starts `0.1.0` — not in lockstep with core/react/hydrogen.
- Run `pnpm install` once to register the package in the workspace/lockfile before publish.
- Pre-commit `biome` could not run locally (installed `2.4.14` vs the repo's `2.5.0` config — pre-existing skew); CI runs biome with the correct version. Code follows the documented conventions.
