### PR TITLE
docs(experiments): consent-gate the quick-start exposure example (0.1.1)

### DIFF
--- a/packages/experiments/CHANGELOG.md
+++ b/packages/experiments/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weaverse/experiments
 
+## 0.1.1
+
+- **Docs** — fix the quick-start exposure example: gate `onExpose` on
+  `canTrack()` rather than optional-chaining `window.gtag?.(…)`. A no-op
+  sink (analytics not loaded yet, or consent withheld) otherwise marked the
+  variant exposed without sending, dropping the impression permanently.
+
 ## 0.1.0
 
 Initial release — framework-agnostic A/B testing and experimentation.

--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -73,19 +73,29 @@ export function createWeaverseClient(args) {
 **2. Provide assignments to React and forward exposure to analytics.**
 
 ```tsx
-// app/root.tsx
+// app/root.tsx — App renders inside <Analytics.Provider> (see below)
+import { useAnalytics } from '@shopify/hydrogen'
 import { WeaverseExperiments } from '@weaverse/experiments/react'
 
 export default function App() {
   let { assignments } = useLoaderData<typeof loader>()
+  let { publish, canTrack } = useAnalytics()
+  let tracking = canTrack()
   return (
     <WeaverseExperiments
       value={assignments}
-      onExpose={(a) =>
-        window.gtag?.('event', 'experiment_view', {
-          experiment_id: a.experimentId,
-          variant_id: a.variant.id,
-        })
+      // Attach onExpose only once consent allows it. A sink that silently
+      // no-ops (analytics not loaded yet, or consent withheld) would mark the
+      // variant exposed without sending — and it never retries. See the
+      // "Analytics integration" section for the full setup.
+      onExpose={
+        tracking
+          ? (a) =>
+              publish('custom_experiment_viewed', {
+                experimentId: a.experimentId,
+                variantId: a.variant.id,
+              })
+          : undefined
       }
     >
       <Outlet />

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weaverse/experiments",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Framework-agnostic A/B testing and experimentation for Weaverse — deterministic, storage-free variant assignment",
   "author": "Weaverse",
   "license": "MIT",


### PR DESCRIPTION
Follow-up to #467. Codex flagged the published README quick-start: `onExpose` optional-chained `window.gtag?.(…)`, a silent no-op when analytics isn't loaded or consent is withheld. The exposure tracker records the dedupe key after any non-throwing callback, so that first no-op marked the variant exposed without sending and never retried — early adopters copying the quick-start would silently drop impressions.

Fix: gate `onExpose` on `canTrack()` (matching the Analytics integration example). Bumps `@weaverse/experiments` to 0.1.1 so the npm-visible README is corrected.

No library code change — engine/server/react are unchanged; 34 tests, typecheck, build green.