### PR TITLE
feat(cli): non-interactive flags, generated SESSION_SECRET, demo-first onboarding

### DIFF
--- a/packages/cli/__tests__/environment.test.js
+++ b/packages/cli/__tests__/environment.test.js
@@ -1,0 +1,48 @@
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createEnvFile } from '../src/utils/environment.js'
+import { validateProjectName } from '../src/utils/validation.js'
+
+const SESSION_SECRET_PATTERN = /^SESSION_SECRET="([a-f0-9]{64})"$/m
+
+describe('createEnvFile', () => {
+  let testDir = './test-env-project'
+
+  beforeEach(async () => {
+    await fs.ensureDir(testDir)
+  })
+
+  afterEach(async () => {
+    await fs.remove(testDir)
+  })
+
+  it('injects project id and generates a secure session secret', async () => {
+    await fs.writeFile(
+      `${testDir}/.env.example`,
+      [
+        'SESSION_SECRET="foobar"',
+        'PUBLIC_STORE_DOMAIN=weaverse-hydrogen.myshopify.com',
+        'WEAVERSE_PROJECT_ID=demo-project',
+      ].join('\n')
+    )
+
+    await createEnvFile(testDir, 'merchant-project')
+
+    let env = await fs.readFile(`${testDir}/.env`, 'utf8')
+    let secret = env.match(SESSION_SECRET_PATTERN)?.[1]
+
+    expect(env).toContain('WEAVERSE_PROJECT_ID=merchant-project')
+    expect(secret).toBeTruthy()
+    expect(secret).not.toBe('foobar')
+  })
+})
+
+describe('validateProjectName (guards the overwrite/emptyDir path)', () => {
+  it('rejects traversal and separator names, accepts kebab names', () => {
+    expect(validateProjectName('..')).not.toBe(true)
+    expect(validateProjectName('../evil')).not.toBe(true)
+    expect(validateProjectName('foo/bar')).not.toBe(true)
+    expect(validateProjectName('foo\\bar')).not.toBe(true)
+    expect(validateProjectName('good-name')).toBe(true)
+  })
+})

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weaverse/cli",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "CLI for Weaverse projects",
   "type": "module",
   "main": "index.js",

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -13,6 +13,7 @@ import {
 import {
   checkDirectoryExists,
   validateCommitHash,
+  validateProjectName,
 } from '../utils/validation.js'
 
 /**
@@ -72,6 +73,15 @@ export let createProject = async (argv) => {
           (t) => t.name
         ).join(', ')}`
       )
+    }
+
+    // Validate the name whether it came from a prompt or a CLI flag —
+    // prompts validate inline, but `--project-name` reaches here unchecked
+    // and the overwrite path empties `outputPath` (e.g. `--project-name=..`
+    // would otherwise point `fs.emptyDir` at the parent directory).
+    let nameValidation = validateProjectName(options['project-name'])
+    if (nameValidation !== true) {
+      throw new Error(nameValidation)
     }
 
     // Prepare project path

--- a/packages/cli/src/utils/environment.js
+++ b/packages/cli/src/utils/environment.js
@@ -1,5 +1,8 @@
+import { randomBytes } from 'node:crypto'
 import fs from 'fs-extra'
 import ora from 'ora'
+
+export let generateSessionSecret = () => randomBytes(32).toString('hex')
 
 /**
  * Creates .env file from .env.example template with project-specific values
@@ -24,6 +27,19 @@ export let createEnvFile = async (path, projectId) => {
       )
     } else {
       envContent = `${envExampleContent}\nWEAVERSE_PROJECT_ID=${projectId}`
+    }
+
+    // Hydrogen requires SESSION_SECRET; generate a real one so the template's
+    // placeholder (e.g. "foobar") never ships and users are never asked for it.
+    let sessionSecret = generateSessionSecret()
+    if (envContent.includes('SESSION_SECRET=')) {
+      envContent = envContent.replace(
+        // biome-ignore lint/performance/useTopLevelRegex: the func only run once
+        /^SESSION_SECRET=.*/m,
+        `SESSION_SECRET="${sessionSecret}"`
+      )
+    } else {
+      envContent = `${envContent}\nSESSION_SECRET="${sessionSecret}"`
     }
 
     await fs.writeFile(`${path}/.env`, envContent)

--- a/packages/cli/src/utils/install.js
+++ b/packages/cli/src/utils/install.js
@@ -43,10 +43,29 @@ export let installDependenciesAndRun = async (outputPath, projectName) => {
     console.log(chalk.green('\n🎉 Project created successfully!'))
     console.log(chalk.blue('\nNext steps:'))
     console.log(chalk.gray(`1. cd ${projectName}`))
-    console.log(chalk.gray('2. Pull your Shopify environment variables:'))
-    console.log(chalk.gray('   npx shopify hydrogen env pull'))
-    console.log(chalk.gray('3. npm run dev'))
-    console.log(chalk.gray('4. Open http://localhost:3456 in your browser\n'))
+    console.log(chalk.gray('2. npm run dev'))
+    console.log(chalk.gray('3. Open http://localhost:3456 in your browser'))
+    console.log(
+      chalk.gray(
+        '\nThe demo store works out of the box. To connect your own Shopify store later:'
+      )
+    )
+    console.log(
+      chalk.gray(
+        '- Store on a Shopify plan: install the Hydrogen sales channel (https://apps.shopify.com/hydrogen),'
+      )
+    )
+    console.log(
+      chalk.gray(
+        '  create a Hydrogen storefront, then run: npx shopify hydrogen env pull'
+      )
+    )
+    console.log(
+      chalk.gray(
+        '- Development store: install the Headless sales channel (https://apps.shopify.com/headless)'
+      )
+    )
+    console.log(chalk.gray('  and copy the Storefront API values into .env\n'))
 
     return true
   } catch (error) {
@@ -92,9 +111,28 @@ export let showManualInstructions = (projectName) => {
   console.log(chalk.green('\n🎉 Project created successfully!'))
   console.log(chalk.blue('\nNext steps:'))
   console.log(chalk.gray(`1. cd ${projectName}`))
-  console.log(chalk.gray('2. Pull your Shopify environment variables:'))
-  console.log(chalk.gray('   npx shopify hydrogen env pull'))
-  console.log(chalk.gray('3. npm install'))
-  console.log(chalk.gray('4. npm run dev'))
-  console.log(chalk.gray('5. Open http://localhost:3456 in your browser\n'))
+  console.log(chalk.gray('2. npm install'))
+  console.log(chalk.gray('3. npm run dev'))
+  console.log(chalk.gray('4. Open http://localhost:3456 in your browser'))
+  console.log(
+    chalk.gray(
+      '\nThe demo store works out of the box. To connect your own Shopify store later:'
+    )
+  )
+  console.log(
+    chalk.gray(
+      '- Store on a Shopify plan: install the Hydrogen sales channel (https://apps.shopify.com/hydrogen),'
+    )
+  )
+  console.log(
+    chalk.gray(
+      '  create a Hydrogen storefront, then run: npx shopify hydrogen env pull'
+    )
+  )
+  console.log(
+    chalk.gray(
+      '- Development store: install the Headless sales channel (https://apps.shopify.com/headless)'
+    )
+  )
+  console.log(chalk.gray('  and copy the Storefront API values into .env\n'))
 }


### PR DESCRIPTION
## Changes (`@weaverse/cli`)

- **Non-interactive mode**: `--yes`/`-y` and `--ci` fail fast on missing required options instead of prompting; `--force` overwrites an existing non-empty target dir; `--dev` starts the dev server after install.
- **`SESSION_SECRET` generation**: `createEnvFile()` writes a random 64-hex secret via `node:crypto` — agents/users never have to invent one, and the `foobar` placeholder never ships.
- **`--no-install` fix** for yargs' `install === false` shape.
- **Demo-first next steps**: CLI output now says run dev + open localhost first, then connect the real Shopify store (Hydrogen sales channel for plan stores, Headless for development stores).
- **Safety**: `--project-name` is validated before the `--force` removal path — a name like `..` or `foo/bar` is rejected before `fs.remove()` can point outside the target folder (found by autoreview).

## Verification
- `npm test`: 4/4 tests (env-file secret generation + traversal-name rejection)
- Smoke: `create --template=pilot --no-install -y --force` scaffolds, injects `WEAVERSE_PROJECT_ID`, generates 64-hex `SESSION_SECRET`
- Codex autoreview: clean after the traversal guard

Docs already updated in Weaverse/docs (`weaverse-cli.mdx` documents the new flags and current templates).