### PR TITLE
Add Next low-risk parity helpers

### DIFF
--- a/.specs/2026-06-21--next-studio-bridge/claude-review-pr481.md
+++ b/.specs/2026-06-21--next-studio-bridge/claude-review-pr481.md
@@ -1,0 +1,25 @@
+## Verdict
+**APPROVE**
+
+## Blocking findings
+None.
+
+## Non-blocking findings
+
+1. **Silent partial-pagination truncation has no signal to caller** (`packages/next/src/server/server-client.ts:256-298`, `fetchCustomPages`). On a mid-pagination fetch failure or hitting `MAX_CUSTOM_PAGE_PAGES`, the function returns whatever was accumulated so far with only a `console.warn` — the return type gives callers no way to distinguish a complete sitemap from a truncated one. This is intentional 1:1 parity with `packages/hydrogen/src/weaverse-client.ts:857-913` (`fetchCustomPages`), so it's not a regression introduced here, just a pre-existing tradeoff worth a follow-up (e.g. optional `onError`/`meta.truncated` flag) if sitemap completeness ever becomes a real incident.
+
+2. **`WeaverseNextCustomPageEntry.locale` typed as required `string | null`** (`packages/next/src/types.ts` new `WeaverseNextCustomPageEntry`), but nothing guarantees the backend always sends the key — if omitted, `locale` would be `undefined` at runtime while the type says `string | null`. Purely a type-precision nit; doesn't affect the tested paths.
+
+3. **`getWeaverseNextSeoMetadata`/`formatWeaverseNextSeoMetadata` are exported from both the root `@weaverse/next` entry and `@weaverse/next/server`** (`packages/next/src/index.ts` and `packages/next/src/server.ts`). Confirmed intentional and safe since `seo.ts` has no `next/*`/`react` imports, but worth a one-line README note (currently only documented under `/server`) so consumers know the root import also works.
+
+## Verification notes
+- Cross-checked `formatWeaverseNextSeoMetadata`'s field mapping against the authoritative `PageSEOData` shape in `packages/schema/src/page-seo.ts` — field names (`canonicalUrl`, `openGraph.{title,description,image,type}`, `twitter.{cardType,title,description,image}`, `robots.{index,follow}`) match exactly; no drift.
+- Verified `getWeaverseNextSeoMetadata`'s structural narrowing (`'items' in data && 'id' in data`) is sound: `WeaverseNextPageData` requires both `id`/`items`, while `WeaverseNextLoaderData` only guarantees `page` — no ambiguous overlap in the declared types (`packages/next/src/types.ts:119-139`).
+- Verified `fetchCustomPages`/`_buildCustomPagesUrl` endpoint path, query params, cache-knob wiring (`revalidate`/`tags` → `fetchWithCache`), pagination cap, and partial-failure behavior are a faithful port of `packages/hydrogen/src/weaverse-client.ts:861-913`, including the `cache: 'no-store'` override in design/revision-preview mode inherited from the shared `fetchWithCache` (`packages/next/src/server/server-client.ts:189-227`).
+- `resolveProjectId()` never throws (internal try/catch), so the `if (!projectId)` guard in `fetchCustomPages` correctly handles the unresolved-project case without needing its own try/catch.
+- Resource-picker aliases (`WeaverseBlog`, `WeaverseArticle`, `WeaverseMetaObject`) are trivial type aliases to `WeaverseResourcePickerData`, matching the existing `WeaverseProduct`/`WeaverseCollection` pattern — no runtime surface, low risk.
+- Did not re-run the test/typecheck/build/biome/CI commands myself; relying on Hermes's verification results as reported (all pass) since the diff review didn't surface anything that would contradict them.
+
+## Follow-up slices
+- Confirmed the PR stays within the stated scope (custom-pages sitemap helper, SEO metadata helpers, resource-picker aliases, README/work-log updates). No translation/global-section/multi-runtime work was introduced, consistent with the Weaverse/builder#2659 slicing plan — nothing to flag as out-of-scope.
+- Possible future hardening (non-blocking, not for this PR): surface partial-pagination truncation to callers (see finding 1) if it turns out sitemaps silently losing tail pages becomes an operational issue.

--- a/.specs/2026-06-21--next-studio-bridge/work-logs.md
+++ b/.specs/2026-06-21--next-studio-bridge/work-logs.md
@@ -146,3 +146,31 @@ server-only loaders) are correct; the remaining gap was SDK-side only.
 Publish/pack a new `@weaverse/next` alpha, install it in the POC, and re-run
 the resource-picker smoke: pick a product → loading bar → section renders the
 new product without publish + Studio reload.
+
+## 2026-07-09 — low-risk Hydrogen parity slice
+
+After the dedicated Next Studio bridge path was validated end-to-end in the POC, #2659 was audited for remaining `@weaverse/hydrogen` vs `@weaverse/next` gaps. This slice intentionally tackles low-risk parity before deeper Studio/runtime features.
+
+### Scope
+
+- Add custom-page sitemap helper parity on `WeaverseNextServerClient.fetchCustomPages()`.
+- Add Next Metadata-compatible SEO conversion helpers (`getWeaverseNextSeoMetadata`, `formatWeaverseNextSeoMetadata`).
+- Add missing resource picker data aliases (`WeaverseBlog`, `WeaverseArticle`, `WeaverseMetaObject`) next to product/collection aliases.
+- Update `packages/next/README.md` to reflect the dedicated `/static/studio/next/*` bridge and new helper APIs.
+
+### Non-scope
+
+- Translation/static-text sidecar runtime and save-payload support.
+- Multi-runtime/nested page selection semantics.
+- Global sections.
+- Next request-handler/redirect ownership decision.
+
+### Verification target
+
+```bash
+pnpm --filter @weaverse/next test
+pnpm --filter @weaverse/next typecheck
+pnpm --filter @weaverse/next build
+pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error
+git diff --check
+```

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -11,8 +11,9 @@ It is the Next equivalent of the useful parts of `@weaverse/hydrogen`, but the a
 - Package status: alpha (`0.1.0-alpha.x`).
 - Target runtime: Next App Router.
 - Peer dependencies: `next >=14`, `react >=19`, `react-dom >=19`.
-- Studio bridge: supported through the existing Studio bridge script plus Next-native runtime callbacks.
+- Studio bridge: supported through the dedicated Next Studio bridge script (`/static/studio/next/*`) plus Next-native runtime callbacks.
 - Resource-picker revalidation: supported through per-item loader revalidation, not full-page `router.refresh()` on the happy path.
+- Low-risk Hydrogen parity helpers: custom-page sitemap fetching, Next metadata conversion, and resource-picker type aliases are available.
 
 ## Quick answers for the team
 
@@ -127,6 +128,7 @@ packages/next/src/
   use-weaverse-next-studio.tsx     # Next-native Studio binder using next/navigation
   revalidate-item.ts               # client per-item loader revalidation
   request-info.ts                  # Studio-compatible request info
+  seo.ts                           # Next Metadata-compatible page SEO helpers
   theme-settings-store.ts          # Studio-compatible theme settings store
   types.ts                         # shared public types
   server/
@@ -160,6 +162,7 @@ Main exports:
 - `createWeaverseNextRevalidateHandler(config)` — route-handler factory for Studio per-item loader revalidation.
 - `getWeaverseNextConfigs(...)` — config/env/query resolution.
 - `normalizeNextPageUrl(...)` / `resolveRequestUrl(...)` — stable page URL helpers.
+- `getWeaverseNextSeoMetadata(...)` / `formatWeaverseNextSeoMetadata(...)` — convert Weaverse `page.seo` into a Next Metadata-compatible object.
 
 ### `createWeaverseNextServerClient`
 
@@ -241,6 +244,7 @@ let theme = await weaverse.loadThemeSettings()
 | --- | --- |
 | `loadPage(input?)` | Fetches the page from `/api/public/project`, builds `WeaverseNextLoaderData`, runs component loaders, and returns page/project/config data. In section preview mode it can synthesize a single-section preview page. |
 | `loadThemeSettings(options?)` | Fetches `/api/public/project_configs`, merges schema defaults under merchant settings, returns theme settings/static content/schema data for design mode. |
+| `fetchCustomPages(options?)` | Fetches published custom pages from `/api/public/v1/projects/:projectId/custom-pages` for sitemap generation, paginating automatically and returning partial results if a later page fails. |
 | `fetchWithCache<T>(url, options?)` | Next-aware fetch helper. Uses `cache: 'no-store'` in design/revision preview and `next: { revalidate, tags }` in published mode. |
 | `resolveProjectId()` / `projectId` | Resolves project id from Studio query, config function/string, or env. |
 | `components` | Server component registry. Components may include `schema` and optional `loader`. |
@@ -271,6 +275,43 @@ Loader args match the page-load and revalidation paths:
 - `commerce` — explicit commerce context.
 - `weaverse` — server/client object with `weaverse.storefront` compatibility alias.
 - `context` — request context.
+
+### SEO metadata
+
+Use the server entry in `generateMetadata()` to map Weaverse `page.seo` into a Next Metadata-compatible object:
+
+```ts
+// app/pages/[handle]/page.tsx
+import { getWeaverseNextSeoMetadata } from '@weaverse/next/server'
+
+export async function generateMetadata(props: {
+  params: Promise<{ handle: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
+  let { handle } = await props.params
+  let weaverse = await getWeaverseServerClient(props.searchParams, `/pages/${handle}`)
+  let data = await weaverse.loadPage({ type: 'PAGE', handle })
+  return getWeaverseNextSeoMetadata(data)
+}
+```
+
+The helper is pure and does not import `next/*`; its return shape is intentionally structural so the app can type it as `Metadata` if desired.
+
+### Custom pages for sitemap generation
+
+`fetchCustomPages()` mirrors Hydrogen's sitemap helper and accepts Next cache knobs:
+
+```ts
+let weaverse = await getWeaverseServerClient(Promise.resolve({}), '/')
+let pages = await weaverse.fetchCustomPages({
+  locale: 'en-us',
+  limit: 100,
+  revalidate: 3600,
+  tags: ['weaverse:custom-pages'],
+})
+```
+
+It paginates until the API returns `nextCursor: null`; if a later page fails, it returns the pages already fetched instead of throwing.
 
 ## Rendering in a Next route
 
@@ -443,6 +484,5 @@ app/collections/[handle]/page.tsx            # collection route Weaverse load
 
 - This package is still alpha; API names may change before stable.
 - Next does not provide Hydrogen's global React Router loader context, so apps should keep a small `getWeaverseServerClient(...)` helper.
+- Translation/static-text sidecar parity, multiple Weaverse runtimes on one URL, 404/error-route Studio connection smoke, and global sections are later hardening items.
 - Full Shopify request-handler/redirect parity is app-level follow-up work, not owned by this package yet.
-- Translation/static-text sidecar parity, multiple Weaverse runtimes on one URL, and 404/error-route Studio connection are later hardening items.
-- The Studio bridge currently reuses the existing Studio bridge bundle until a Next-specific bundle is proven necessary.

--- a/packages/next/__tests__/next-server.test.tsx
+++ b/packages/next/__tests__/next-server.test.tsx
@@ -3,6 +3,7 @@ import { createSchema } from '../src/index'
 import {
   createWeaverseNextServerClient,
   getWeaverseNextConfigs,
+  getWeaverseNextSeoMetadata,
   normalizeNextPageUrl,
   resolveRequestUrl,
 } from '../src/server'
@@ -494,7 +495,158 @@ describe('createWeaverseNextServerClient loadThemeSettings', () => {
   })
 })
 
-// ─── 3b. trusted weaverseHost normalization ───────────────────────────
+// ─── 3b. custom pages sitemap helper ─────────────────────────────────
+
+describe('createWeaverseNextServerClient fetchCustomPages', () => {
+  it('should_fetch_paginated_custom_pages_with_locale_and_limit', async () => {
+    let fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [
+            {
+              handle: 'about',
+              lastModified: '2026-07-01T00:00:00.000Z',
+              locale: 'en-us',
+              path: '/pages/about',
+            },
+          ],
+          nextCursor: 'cursor-2',
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [
+            {
+              handle: 'faq',
+              lastModified: '2026-07-02T00:00:00.000Z',
+              locale: 'en-us',
+              path: '/pages/faq',
+            },
+          ],
+          nextCursor: null,
+        })
+      ) as unknown as typeof fetch & { mock: { calls: unknown[][] } }
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      fetch: fetchMock,
+    })
+
+    let pages = await client.fetchCustomPages({
+      locale: 'en-us',
+      limit: 1,
+      revalidate: 3600,
+      tags: ['weaverse:custom-pages'],
+    })
+
+    expect(pages.map((page) => page.handle)).toEqual(['about', 'faq'])
+    let [firstUrl, firstInit] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit & { next?: { revalidate?: number; tags?: string[] } },
+    ]
+    expect(firstUrl).toBe(
+      'https://api.weaverse.io/api/public/v1/projects/proj-123/custom-pages?locale=en-us&limit=1'
+    )
+    expect(firstInit.next).toEqual({
+      revalidate: 3600,
+      tags: ['weaverse:custom-pages'],
+    })
+    let [secondUrl] = fetchMock.mock.calls[1] as [string, RequestInit]
+    expect(secondUrl).toBe(
+      'https://api.weaverse.io/api/public/v1/projects/proj-123/custom-pages?locale=en-us&limit=1&cursor=cursor-2'
+    )
+  })
+
+  it('should_return_partial_results_when_later_page_fails', async () => {
+    let warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    let fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [
+            {
+              handle: 'about',
+              lastModified: '2026-07-01T00:00:00.000Z',
+              locale: null,
+              path: '/pages/about',
+            },
+          ],
+          nextCursor: 'cursor-2',
+        })
+      )
+      .mockRejectedValueOnce(
+        new Error('network down')
+      ) as unknown as typeof fetch
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      fetch: fetchMock,
+    })
+
+    let pages = await client.fetchCustomPages()
+
+    expect(pages).toHaveLength(1)
+    expect(pages[0].handle).toBe('about')
+    warn.mockRestore()
+  })
+})
+
+// ─── 3c. SEO metadata helper ───────────────────────────────────────────
+
+describe('getWeaverseNextSeoMetadata', () => {
+  it('should_convert_weaverse_seo_payload_to_next_metadata_shape', () => {
+    let metadata = getWeaverseNextSeoMetadata({
+      page: {
+        id: 'page-1',
+        items: [],
+        seo: {
+          title: 'SEO title',
+          description: 'SEO description',
+          keywords: 'shop,commerce',
+          canonicalUrl: 'https://shop.example/pages/about',
+          openGraph: {
+            title: 'OG title',
+            description: 'OG description',
+            image: 'https://cdn.example/og.jpg',
+          },
+          twitter: {
+            title: 'Twitter title',
+            image: 'https://cdn.example/tw.jpg',
+          },
+          robots: { index: false, follow: true },
+        },
+      },
+    })
+
+    expect(metadata).toEqual({
+      title: 'SEO title',
+      description: 'SEO description',
+      keywords: 'shop,commerce',
+      alternates: { canonical: 'https://shop.example/pages/about' },
+      openGraph: {
+        title: 'OG title',
+        description: 'OG description',
+        images: ['https://cdn.example/og.jpg'],
+        type: 'website',
+      },
+      twitter: {
+        card: 'summary',
+        title: 'Twitter title',
+        images: ['https://cdn.example/tw.jpg'],
+      },
+      robots: { index: false, follow: true },
+    })
+  })
+
+  it('should_return_default_index_follow_when_seo_is_missing', () => {
+    expect(getWeaverseNextSeoMetadata(null)).toEqual({
+      robots: { index: true, follow: true },
+    })
+  })
+})
+
+// ─── 3d. trusted weaverseHost normalization ───────────────────────────
 
 describe('getWeaverseNextConfigs trusted host normalization', () => {
   it('should_canonicalize_a_trusted_query_host_to_its_origin', () => {

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -46,6 +46,11 @@ export {
   WeaverseNextRuntime,
 } from './runtime'
 export {
+  formatWeaverseNextSeoMetadata,
+  getWeaverseNextSeoMetadata,
+  type WeaverseNextSeoMetadata,
+} from './seo'
+export {
   WeaverseNextStudioBridge,
   type WeaverseNextStudioBridgeProps,
 } from './studio-bridge'
@@ -68,7 +73,10 @@ export {
   createWeaverseNextThemeSettingsStore,
 } from './theme-settings-store'
 export type {
+  WeaverseArticle,
+  WeaverseBlog,
   WeaverseCollection,
+  WeaverseMetaObject,
   WeaverseNextClient,
   WeaverseNextClientConfig,
   WeaverseNextCommerceContext,
@@ -76,6 +84,8 @@ export type {
   WeaverseNextComponentData,
   WeaverseNextComponentLoaderArgs,
   WeaverseNextComponentProps,
+  WeaverseNextCustomPageEntry,
+  WeaverseNextFetchCustomPagesOptions,
   WeaverseNextI18n,
   WeaverseNextLoaderData,
   WeaverseNextLoadPageInput,

--- a/packages/next/src/seo.ts
+++ b/packages/next/src/seo.ts
@@ -1,0 +1,100 @@
+import type { PageSEOData } from '@weaverse/schema'
+import type { WeaverseNextLoaderData, WeaverseNextPageData } from './types'
+
+export interface WeaverseNextSeoMetadata {
+  alternates?: { canonical?: string }
+  description?: string
+  keywords?: string
+  openGraph?: {
+    description?: string
+    images?: string[]
+    title?: string
+    type?: string
+  }
+  robots: {
+    follow: boolean
+    index: boolean
+  }
+  title?: string
+  twitter?: {
+    card?: string
+    description?: string
+    images?: string[]
+    title?: string
+  }
+}
+
+function hasOpenGraphContent(seo: PageSEOData['openGraph']): boolean {
+  return Boolean(seo?.title || seo?.description || seo?.image || seo?.type)
+}
+
+function hasTwitterContent(seo: PageSEOData['twitter']): boolean {
+  return Boolean(seo?.title || seo?.description || seo?.image || seo?.cardType)
+}
+
+export function formatWeaverseNextSeoMetadata(
+  seo: PageSEOData | null | undefined
+): WeaverseNextSeoMetadata {
+  let index = seo?.robots?.index !== false
+  let follow = seo?.robots?.follow !== false
+  let metadata: WeaverseNextSeoMetadata = {
+    robots: { index, follow },
+  }
+
+  if (!seo) {
+    return metadata
+  }
+
+  if (seo.title) {
+    metadata.title = seo.title
+  }
+  if (seo.description) {
+    metadata.description = seo.description
+  }
+  if (seo.keywords) {
+    metadata.keywords = seo.keywords
+  }
+  if (seo.canonicalUrl) {
+    metadata.alternates = { canonical: seo.canonicalUrl }
+  }
+
+  let openGraph = seo.openGraph
+  if (hasOpenGraphContent(openGraph)) {
+    metadata.openGraph = {
+      title: openGraph?.title,
+      description: openGraph?.description,
+      images: openGraph?.image ? [openGraph.image] : undefined,
+      type: openGraph?.type || 'website',
+    }
+  }
+
+  let twitter = seo.twitter
+  if (hasTwitterContent(twitter)) {
+    metadata.twitter = {
+      card: twitter?.cardType || 'summary',
+      title: twitter?.title,
+      description: twitter?.description,
+      images: twitter?.image ? [twitter.image] : undefined,
+    }
+  }
+
+  return metadata
+}
+
+export function getWeaverseNextSeoMetadata(
+  data:
+    | WeaverseNextLoaderData
+    | WeaverseNextPageData
+    | { page?: WeaverseNextPageData | null }
+    | null
+    | undefined
+): WeaverseNextSeoMetadata {
+  if (!data) {
+    return formatWeaverseNextSeoMetadata(null)
+  }
+  let page =
+    'items' in data && 'id' in data
+      ? (data as WeaverseNextPageData)
+      : ((data as { page?: WeaverseNextPageData | null }).page ?? null)
+  return formatWeaverseNextSeoMetadata(page?.seo ?? null)
+}

--- a/packages/next/src/server.ts
+++ b/packages/next/src/server.ts
@@ -6,6 +6,11 @@
 // `context.weaverse.loadPage(...)` pattern. Kept on a dedicated subpath so the
 // root `@weaverse/next` entry stays free of server-only fetch assumptions.
 
+export {
+  formatWeaverseNextSeoMetadata,
+  getWeaverseNextSeoMetadata,
+  type WeaverseNextSeoMetadata,
+} from './seo'
 export { getWeaverseNextConfigs } from './server/configs'
 export {
   normalizeNextPageUrl,
@@ -21,6 +26,8 @@ export type {
   WeaverseNextBaseConfigs,
   WeaverseNextCacheConfig,
   WeaverseNextConfigs,
+  WeaverseNextCustomPageEntry,
+  WeaverseNextFetchCustomPagesOptions,
   WeaverseNextFetchOptions,
   WeaverseNextProjectId,
   WeaverseNextServerClient,

--- a/packages/next/src/server/server-client.ts
+++ b/packages/next/src/server/server-client.ts
@@ -8,6 +8,8 @@ import type {
   WeaverseNextComponent,
   WeaverseNextComponentData,
   WeaverseNextConfigs,
+  WeaverseNextCustomPageEntry,
+  WeaverseNextFetchCustomPagesOptions,
   WeaverseNextFetchOptions,
   WeaverseNextLoaderData,
   WeaverseNextLoadPageInput,
@@ -28,6 +30,7 @@ import { normalizeNextPageUrl, resolveRequestUrl } from './normalize-page-url'
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000
 const RANDOM_ID_RADIX = 36
 const RANDOM_ID_SLICE_START = 2
+const MAX_CUSTOM_PAGE_PAGES = 100
 
 const JSON_HEADERS = {
   'Content-Type': 'application/json',
@@ -221,6 +224,70 @@ class NextServerClient implements WeaverseNextServerClient {
     } finally {
       clearTimeout(timeoutId)
     }
+  }
+
+  /**
+   * Fetch all published custom pages for sitemap generation. Mirrors Hydrogen's
+   * helper but uses Next's fetch cache knobs (`revalidate` / `tags`). It returns
+   * accumulated results on partial pagination failure so a single API hiccup
+   * does not break sitemap generation entirely.
+   */
+  fetchCustomPages = async (
+    options: WeaverseNextFetchCustomPagesOptions = {}
+  ): Promise<WeaverseNextCustomPageEntry[]> => {
+    let projectId = await this.resolveProjectId()
+    let entries: WeaverseNextCustomPageEntry[] = []
+    if (!projectId) {
+      console.warn(
+        '[WeaverseNext] Failed to fetch custom pages: missing projectId'
+      )
+      return entries
+    }
+
+    let cursor: string | null = null
+    for (let page = 0; page < MAX_CUSTOM_PAGE_PAGES; page += 1) {
+      let params = new URLSearchParams()
+      if (options.locale) {
+        params.set('locale', options.locale)
+      }
+      if (options.limit) {
+        params.set('limit', String(options.limit))
+      }
+      if (cursor) {
+        params.set('cursor', cursor)
+      }
+
+      let qs = params.toString()
+      let url = `${this._baseConfigs.weaverseApiBase}/api/public/v1/projects/${projectId}/custom-pages${
+        qs ? `?${qs}` : ''
+      }`
+
+      try {
+        let result = await this.fetchWithCache<{
+          data?: WeaverseNextCustomPageEntry[]
+          nextCursor?: string | null
+        }>(url, {
+          revalidate: options.revalidate,
+          tags: options.tags,
+        })
+        entries.push(...(result.data ?? []))
+        if (!result.nextCursor) {
+          return entries
+        }
+        cursor = result.nextCursor
+      } catch (error) {
+        let message = error instanceof Error ? error.message : String(error)
+        console.warn(
+          entries.length === 0
+            ? `[WeaverseNext] Failed to fetch custom pages: ${message}`
+            : `[WeaverseNext] Custom pages pagination interrupted: ${message}`
+        )
+        return entries
+      }
+    }
+
+    console.warn('[WeaverseNext] Custom pages pagination cap reached')
+    return entries
   }
 
   private _generateFallbackPage(message: string): WeaverseNextPageData {

--- a/packages/next/src/server/server-client.ts
+++ b/packages/next/src/server/server-client.ts
@@ -226,6 +226,27 @@ class NextServerClient implements WeaverseNextServerClient {
     }
   }
 
+  private _buildCustomPagesUrl(
+    projectId: string,
+    options: WeaverseNextFetchCustomPagesOptions,
+    cursor: string | null
+  ) {
+    let params = new URLSearchParams()
+    if (options.locale) {
+      params.set('locale', options.locale)
+    }
+    if (options.limit) {
+      params.set('limit', String(options.limit))
+    }
+    if (cursor) {
+      params.set('cursor', cursor)
+    }
+    let qs = params.toString()
+    return `${this._baseConfigs.weaverseApiBase}/api/public/v1/projects/${projectId}/custom-pages${
+      qs ? `?${qs}` : ''
+    }`
+  }
+
   /**
    * Fetch all published custom pages for sitemap generation. Mirrors Hydrogen's
    * helper but uses Next's fetch cache knobs (`revalidate` / `tags`). It returns
@@ -246,21 +267,7 @@ class NextServerClient implements WeaverseNextServerClient {
 
     let cursor: string | null = null
     for (let page = 0; page < MAX_CUSTOM_PAGE_PAGES; page += 1) {
-      let params = new URLSearchParams()
-      if (options.locale) {
-        params.set('locale', options.locale)
-      }
-      if (options.limit) {
-        params.set('limit', String(options.limit))
-      }
-      if (cursor) {
-        params.set('cursor', cursor)
-      }
-
-      let qs = params.toString()
-      let url = `${this._baseConfigs.weaverseApiBase}/api/public/v1/projects/${projectId}/custom-pages${
-        qs ? `?${qs}` : ''
-      }`
+      let url = this._buildCustomPagesUrl(projectId, options, cursor)
 
       try {
         let result = await this.fetchWithCache<{

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -2,7 +2,7 @@ import type {
   WeaverseElement,
   WeaverseResourcePickerData,
 } from '@weaverse/react'
-import type { PageType, SchemaType } from '@weaverse/schema'
+import type { PageSEOData, PageType, SchemaType } from '@weaverse/schema'
 import type { ComponentType, ForwardRefExoticComponent, ReactNode } from 'react'
 
 export interface WeaverseNextRequestInfo {
@@ -121,6 +121,8 @@ export interface WeaverseNextPageData {
   items: WeaverseNextComponentData[]
   name?: string
   rootId?: string
+  /** Page-level SEO metadata published by Weaverse Builder. */
+  seo?: PageSEOData | null
   [key: string]: unknown
 }
 
@@ -220,6 +222,9 @@ export interface WeaverseNextClient {
 
 export type WeaverseProduct = WeaverseResourcePickerData
 export type WeaverseCollection = WeaverseResourcePickerData
+export type WeaverseBlog = WeaverseResourcePickerData
+export type WeaverseArticle = WeaverseResourcePickerData
+export type WeaverseMetaObject = WeaverseResourcePickerData
 
 // ─── Server client (`@weaverse/next/server`) ──────────────────────────────
 
@@ -309,6 +314,21 @@ export interface WeaverseNextThemeSettingsResponse {
 export interface WeaverseNextThemeSettingsOptions
   extends WeaverseNextCacheConfig {}
 
+export interface WeaverseNextCustomPageEntry {
+  changeFrequency?: 'daily' | 'weekly' | 'monthly'
+  handle: string
+  lastModified: string
+  locale: string | null
+  path: string
+  priority?: number
+}
+
+export interface WeaverseNextFetchCustomPagesOptions
+  extends WeaverseNextCacheConfig {
+  limit?: number
+  locale?: string
+}
+
 /**
  * Config for {@link createWeaverseNextServerClient}. Unlike
  * {@link WeaverseNextClientConfig} (which delegates network I/O to injected
@@ -346,6 +366,9 @@ export interface WeaverseNextServerClientConfig {
 export interface WeaverseNextServerClient extends WeaverseNextClient {
   /** Public, client-safe resolved configs (no server secrets). */
   configs: WeaverseNextConfigs
+  fetchCustomPages: (
+    options?: WeaverseNextFetchCustomPagesOptions
+  ) => Promise<WeaverseNextCustomPageEntry[]>
   fetchWithCache: <T = unknown>(
     url: string,
     options?: WeaverseNextFetchOptions


### PR DESCRIPTION
Refs Weaverse/builder#2659.

Adds the first low-risk Hydrogen parity slice for `@weaverse/next` after the dedicated Next Studio bridge smoke passed.

- Add `fetchCustomPages()` to the Next server client for sitemap/custom-page parity.
- Add Next Metadata-compatible SEO helpers for Weaverse `page.seo`.
- Export missing resource picker aliases and update the Next package docs/work-log.

Verification:
- `pnpm --filter @weaverse/next test`
- `pnpm --filter @weaverse/next typecheck`
- `pnpm --filter @weaverse/next build`
- `pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error`
- `git diff --check`
- `autoreview-copilot --mode branch --base origin/main`