### PR TITLE
Add Next root theme provider

### DIFF
--- a/.specs/2026-06-21--next-studio-bridge/README.md
+++ b/.specs/2026-06-21--next-studio-bridge/README.md
@@ -7,7 +7,7 @@
 | **Issue**        | [Weaverse/builder#2533](https://github.com/Weaverse/builder/issues/2533) |
 | **Branch**       | N/A (design-only spec; public PR [Weaverse/weaverse#470](https://github.com/Weaverse/weaverse/pull/470)) |
 | **Created**      | 2026-06-21                                                |
-| **Last Updated** | 2026-06-21                                                |
+| **Last Updated** | 2026-07-09                                                |
 
 ## Original Prompt
 

--- a/.specs/2026-06-21--next-studio-bridge/claude-handoff-next-root-theme-provider-implementation.md
+++ b/.specs/2026-06-21--next-studio-bridge/claude-handoff-next-root-theme-provider-implementation.md
@@ -1,0 +1,134 @@
+# Claude handoff: implement Next root theme provider
+
+Repo: `/Users/hta218/Documents/work/workspace/weaverse`
+Branch: `feat/next-root-theme-provider`
+
+## Goal
+
+Implement the SDK slice from `.specs/2026-06-21--next-studio-bridge/next-theme-provider-design.md`:
+
+- add a root-owned theme settings provider for `@weaverse/next`
+- make route-scoped `WeaverseNextProvider` adopt that ambient root store instead of creating a second store
+- keep behavior backward-compatible when no root provider is mounted
+
+This is SDK package work only. Do not modify the POC repo in this run.
+
+## Context / product reasoning
+
+Published mode is the priority. In Hydrogen/Pilot, global modules render once in root under `withWeaverse(RootLayout)` and read `useThemeSettings()` from a root-owned theme store:
+
+- Pilot `app/root.tsx`: `Layout = withWeaverse(RootLayout)`; root renders `GlobalStyle`, `Header`, `Footer`, `NewsletterPopup` once.
+- Pilot `app/.server/root.ts`: root loader returns `weaverseTheme: context.weaverse.loadThemeSettings()`.
+- Hydrogen `withWeaverse()` creates the theme store at root and `useStudio(weaverse)` attaches that same store to `weaverse.internal.themeSettingsStore`; Studio edits call `updateThemeSettings()` on that store.
+
+Next must match this shape:
+
+```tsx
+app/layout.tsx
+  <WeaverseNextRootProvider initialThemeSettings={theme.theme} themeSchema={theme.schema}>
+    <WeaverseNextStudioConnect />
+    <Header />
+    {children}
+    <Footer />
+  </WeaverseNextRootProvider>
+
+route/page wrapper
+  <WeaverseNextProvider client={client} pageData={...}>
+    <WeaverseNextRenderer />
+  </WeaverseNextProvider>
+```
+
+The page runtime/renderer remains route-scoped, but the theme settings store must be root-owned and shared with route runtimes.
+
+## Current relevant files
+
+- `packages/next/src/provider.tsx`
+- `packages/next/src/hooks.ts`
+- `packages/next/src/theme-settings-store.ts`
+- `packages/next/src/renderer.tsx`
+- `packages/next/src/runtime.ts`
+- `packages/next/src/index.ts`
+- `packages/next/src/types.ts`
+- `packages/next/__tests__/next-adapter.test.tsx`
+
+## Required behavior
+
+1. New public client component export:
+   - likely `WeaverseNextRootProvider`
+   - props: `children`, `initialThemeSettings?: Record<string, unknown>`, `themeSchema?: unknown`, optionally `publicEnv?: Record<string, string | undefined>` if the existing store supports it.
+
+2. Root provider must create exactly one `WeaverseNextThemeSettingsStore` for its mounted lifetime.
+   - Use `useRef`, not `useMemo`, so a parent re-render does not replace the store instance.
+   - If `initialThemeSettings` changes after mount, update the existing store via `updateThemeSettings()`; do not replace it.
+
+3. `useThemeSettings()` must work for root-level consumers under `WeaverseNextRootProvider` even if there is no route-level `WeaverseNextProvider` above them.
+   - Prefer making root provider also provide `WeaverseNextContext` with a minimal value so existing `useThemeSettings()` keeps working.
+   - Keep root/page/commerce hooks outside route provider behavior sensible: `useThemeSettings()` should work at root, but `useWeaverseRootData`/`useWeaversePageData`/`useWeaverseCommerce` can still return undefined values if only root provider is present, unless you think preserving throw is better. Tests should define the contract clearly.
+
+4. `WeaverseNextProvider` must adopt the ambient root store if present.
+   - If root provider exists, do not create a second theme store.
+   - If `themeSettings` prop / `client.themeSettings` is provided in route provider, merge it into the root store (update existing store), not replace the store.
+   - If no root provider exists, fallback to current behavior unchanged.
+
+5. `WeaverseNextRenderer`/`runtime.ts` should not need changes unless tests prove otherwise.
+   - It already passes `context.themeSettingsStore` to runtime.
+   - Studio updates should reach the same root store once adoption works.
+
+6. Export new API from `packages/next/src/index.ts` and types as needed.
+
+7. Update `packages/next/README.md` minimally with a short root provider example. Do not over-document.
+
+8. Update `.specs/2026-06-21--next-studio-bridge/work-logs.md` with a short entry and verification placeholders.
+
+## TDD requirements
+
+Add focused tests in `packages/next/__tests__/next-adapter.test.tsx` or a new nearby test file.
+
+Minimum tests:
+
+1. Root-level consumer:
+   - render `<WeaverseNextRootProvider initialThemeSettings={{ topbarText: 'Root free shipping' }}> <Probe useThemeSettings /> </WeaverseNextRootProvider>`
+   - expect output contains `Root free shipping`.
+
+2. Route provider adopts root store:
+   - create root provider with `topbarText: 'Root'`
+   - inside it render `WeaverseNextProvider client={client with themeSettings: { topbarText: 'Route' }}` and a `Probe` using `useThemeSettings()`
+   - expected: after render snapshot should reflect merged/route value if route supplies override. If SSR/static render cannot observe effect timing, design around initial merge synchronously or adjust expected behavior. Prefer synchronous initial merge to avoid flash.
+
+3. Renderer/runtime uses root store:
+   - render root provider + route provider + `WeaverseNextRenderer` with a simple page.
+   - obtain/runtime check if practical, or use a component that reads `useThemeSettings()` inside the rendered tree.
+   - assert the runtime internal store is the same store when possible.
+
+4. Backward compatibility:
+   - existing `WeaverseNextProvider client={client with themeSettings}` without root provider still exposes theme settings as before.
+
+Run targeted test after writing RED before implementation if practical; then implement.
+
+## Commands
+
+After implementation, run:
+
+```bash
+pnpm --filter @weaverse/next test -- __tests__/next-adapter.test.tsx
+pnpm --filter @weaverse/next typecheck
+pnpm --filter @weaverse/next build
+pnpm --filter @weaverse/next lint
+```
+
+If package scripts differ, inspect `packages/next/package.json` and run the closest available commands.
+
+## Guardrails
+
+- Do not commit or push.
+- Do not touch npm version/publish files.
+- Do not modify Builder repo or POC repo.
+- Do not add broad API surface beyond the root provider + ambient adoption.
+- Keep implementation simple and additive.
+
+## Report back
+
+Print:
+- changed files
+- tests/commands run and result
+- any unresolved issue

--- a/.specs/2026-06-21--next-studio-bridge/work-logs.md
+++ b/.specs/2026-06-21--next-studio-bridge/work-logs.md
@@ -204,3 +204,75 @@ git diff --check                        # clean
 ### Remaining risk
 
 - This is package-level unit coverage of the script-loading behavior only; it does not exercise a real Next `not-found.tsx`/`error.tsx` route or the browser DOM. Manual/E2E confirmation in the POC (mount `WeaverseNextStudioConnect` in root layout, hit a 404 route in design mode, confirm the bridge script tag appears) is still open.
+
+## 2026-07-09 — root-owned theme provider (`next-theme-provider-design.md` implementation slice)
+
+Implemented the SDK slice from `next-theme-provider-design.md`: a root-owned theme settings store shared between global modules (`Header`/`Footer`, mounted once in `app/layout.tsx`) and the route-scoped page runtime, matching Hydrogen's `withWeaverse()` root store split.
+
+### Scope
+
+- Added `WeaverseNextRootProvider` (`packages/next/src/root-provider.tsx`, `'use client'`): creates exactly one `WeaverseNextThemeSettingsStore` via `useRef` (not `useMemo`, so a parent re-render never replaces it), seeded from `initialThemeSettings`/`themeSchema`/`publicEnv`. Updates the existing store in place (`updateThemeSettings`) if `initialThemeSettings` changes identity after mount, rather than replacing it. Also renders `WeaverseNextContext` with a minimal value (`{ themeSettings, themeSettingsStore }`) so `useThemeSettings()` works for components mounted directly under the root provider, with no route-level `WeaverseNextProvider` above them.
+- Added ambient-store adoption to `WeaverseNextProvider` (`packages/next/src/provider.tsx`): reads `WeaverseNextRootContext` via `useContext`; if present, reuses `rootContext.themeSettingsStore` instead of creating a second store (the fallback `useMemo`-created store isn't even constructed in that case). If the route also supplies `themeSettings`/`client.themeSettings`, merges that data into the adopted root store in place inside a `useEffect` (guarded by a ref keyed on value identity so it doesn't re-merge/re-notify every effect run) — the root's initial theme is authoritative for SSR, and the route override applies after client mount. Apps that never mount `WeaverseNextRootProvider` fall back to the pre-existing per-render `useMemo` store, unchanged (still synchronous on SSR).
+- `WeaverseNextRenderer`/`runtime.ts` needed no changes — they already read `context.themeSettingsStore` and pass it through to `runtime.internal.themeSettingsStore`, so once the route provider adopts the root store, the page runtime and Studio's `updateThemeSettings()` calls land on the same instance the root modules read.
+- Exported `WeaverseNextRootProvider`, `WeaverseNextRootProviderProps`, `WeaverseNextRootContextValue` from `packages/next/src/index.ts`.
+- `provider.tsx` and `root-provider.tsx` have a (safe) circular import — each only references the other's export inside a function body (`useContext`/JSX), never at module top-level evaluation, so this is fine under ESM and confirmed clean in the `tsup` build.
+- Added a `## Root theme provider` section to `packages/next/README.md` with a minimal `app/layout.tsx` example and a note on the adoption/merge/fallback contract.
+
+### Tests
+
+Added a `WeaverseNextRootProvider` describe block to `packages/next/__tests__/next-adapter.test.tsx` (5 new tests): root-only consumer, root's SSR value staying authoritative even when a route provider carries pending route theme data (the merge itself now runs in a client-only effect, so it doesn't fire under `renderToStaticMarkup`), root-only settings preserved when the route provider has no explicit theme data, the page renderer (`WeaverseNextRenderer`) observing the same root store instance, and unchanged backward-compatible behavior with no root provider mounted.
+
+Hit one test-fixture pitfall worth flagging for future SDK test authors: `@weaverse/core`'s `Weaverse.itemInstances` is a **process-wide static `Map` keyed by item id** (`packages/core/src/core.ts:89`), and `Weaverse.initProject` calls `itemInstance.setData(item)` on an id collision instead of constructing a fresh item — so reusing a fixture item id like `'item-root'` across unrelated tests in the same file (even with different item `type`s) silently corrupts a *later* test's rendered output. Fixed by giving the new renderer test unique page/item ids (`'page-theme-aware'` / `'theme-aware-root'`); this is pre-existing library behavior, not a new bug introduced by this slice.
+
+### Verification
+
+```bash
+pnpm --filter @weaverse/next test       # 5 files, 81 tests passed
+pnpm --filter @weaverse/next typecheck  # passed
+pnpm --filter @weaverse/next build      # passed (tsup: ESM/CJS/DTS all succeeded)
+pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error  # clean
+```
+
+### Non-scope
+
+- Starter convention files (`app/weaverse-next/root-provider.tsx`, `loadWeaverseNextRootTheme()`, moving `Header`/`Footer` in the POC) — POC repo untouched per this run's guardrails.
+- Design-mode client-side theme refresh before Studio's own push (flagged as an open product/UX question in the design doc, not a technical blocker).
+- Translation/static-text sidecar, global sections, i18n beyond passthrough, redirects.
+
+### Remaining risk
+
+- Not yet verified against a real Next App Router app (root render smoke, navigation-without-remount smoke, Studio edit propagation smoke from the design doc's verification plan are all POC-level manual/E2E steps, not covered by this package-level unit slice).
+
+## 2026-07-09 — autoreview fixes on the root-owned theme provider slice
+
+Fixed both `[P2]` findings from `autoreview-next-root-theme-provider.md` against the root-owned theme provider slice above.
+
+### Scope
+
+- `packages/next/src/root-provider.tsx`: `rootContextValue` and `contextValue` were plain object literals rebuilt every render with a new identity even though the underlying `themeSettingsStore` (`useRef`-stable) never changes — causing every `useThemeSettings()` consumer (root `Header`/`Footer`) to re-render on every root layout re-render. Wrapped both in `useMemo` keyed on `themeSettingsStore`.
+- `packages/next/src/provider.tsx`: the route-level merge of `themeSettings`/`client.themeSettings` into the adopted root store ran directly in the render function body, guarded only by a ref. Mutating a store shared outside the component's subtree during render violates React's pure-render contract and is a latent correctness risk under concurrent rendering/StrictMode double-invocation, even though it worked for the primary SSR path. Moved the merge into a `useEffect` (same ref guard, now keyed off effect re-runs instead of render re-runs).
+- `packages/next/src/provider.tsx`: removed `themeSettingsValue` from the context `value` memo dependencies. In fallback mode the theme value is represented by a new `themeSettingsStore`; in root-adoption mode the post-mount merge effect notifies `useThemeSettings()` subscribers. Keeping `themeSettingsValue` there would recreate context with a stale root snapshot before the effect fires, causing an avoidable extra render.
+
+### Product semantics change
+
+Moving the merge to an effect changes what SSR renders when a route still passes `themeSettings`/`client.themeSettings` while a root provider is mounted: previously the merge was synchronous so SSR showed the *route's* value; now the merge is client-only, so SSR shows the *root's* initial value, and the route override applies after client mount. This is the intended direction, not an accepted regression — routes shouldn't be loading their own theme settings by default in the final starter, and the root's published-mode initial theme is the priority. Backward compatibility when no root provider is mounted is unchanged: `WeaverseNextProvider client={client with themeSettings}` still renders those settings synchronously on SSR via its own fallback store.
+
+### Tests
+
+- Renamed/rewrote `should_have_route_provider_adopt_the_root_store_and_merge_route_theme_settings` to `should_render_root_ssr_value_even_when_route_provider_carries_pending_theme_data` — now asserts SSR renders the root's value, not the route's, since the merge effect never runs under `renderToStaticMarkup`.
+- Rewrote `should_share_the_same_theme_store_between_root_and_the_page_renderer` to drop the route-level `themeSettings` override (which no longer merges synchronously) and instead prove store sharing by asserting the renderer/runtime path observes the root's own value directly.
+- The client-only merge effect itself has no dedicated unit test: this package's Vitest config runs in a plain `node` environment (no `jsdom`/`react-dom/test-utils`), and every existing provider test renders via `renderToStaticMarkup`, which never executes effects. This is a pre-existing test-environment gap, not something newly introduced by this fix.
+
+### Verification
+
+```bash
+pnpm --filter @weaverse/next test -- __tests__/next-adapter.test.tsx
+pnpm --filter @weaverse/next typecheck
+pnpm --filter @weaverse/next build
+pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error
+git diff --check
+```
+
+### Remaining risk
+
+- The client-only merge effect (route theme data landing in the root store after mount, and root `Header`/`Footer` re-rendering from it) is unverified by an automated test for the reason above — still an open item for a future jsdom-enabled test pass or POC-level manual check.

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -372,6 +372,57 @@ export function WeaversePage({ data }: { data: WeaverseNextLoaderData }) {
 }
 ```
 
+## Root theme provider
+
+Global modules (`Header`, `Footer`, popups, a CSS-var bridge) render once in
+`app/layout.tsx`, outside any route's `WeaverseNextProvider`. Mount
+`WeaverseNextRootProvider` there so `useThemeSettings()` works for them too,
+and so route-level providers share one theme settings store instead of each
+creating their own — matching Hydrogen's root-owned `withWeaverse()` store.
+
+```tsx
+// app/layout.tsx
+import { WeaverseNextRootProvider } from '@weaverse/next'
+import { getWeaverseServerClient } from './weaverse-next/server'
+
+export default async function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  let weaverse = await getWeaverseServerClient(Promise.resolve({}), '/')
+  let theme = await weaverse.loadThemeSettings()
+
+  return (
+    <html lang="en">
+      <body>
+        <WeaverseNextRootProvider
+          initialThemeSettings={theme.theme}
+          themeSchema={theme.schema}
+        >
+          <Header />
+          {children}
+          <Footer />
+        </WeaverseNextRootProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+A route's `WeaverseNextProvider` automatically adopts the root store when one
+is mounted above it, instead of creating a second one — so Studio's live
+edits reach both the root modules and the page renderer. The root's initial
+theme is authoritative for SSR: routes should not load their own theme
+settings in the final starter. If a route still carries
+`themeSettings`/`client.themeSettings` (e.g. mid-migration), that data merges
+into the root store in a client-only effect after mount, not during render —
+so SSR always renders the root's value, with no render-phase mutation of the
+shared store. Apps that don't mount `WeaverseNextRootProvider` see no
+behavior change: `WeaverseNextProvider` falls back to creating its own store
+and still renders `themeSettings`/`client.themeSettings` synchronously on
+SSR, same as before.
+
 ## Studio setup
 
 Studio has two separate pieces.

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -18,6 +18,7 @@ import {
   useWeaverseRootData,
   WeaverseNextProvider,
   WeaverseNextRenderer,
+  WeaverseNextRootProvider,
   WeaverseNextStudioConnect,
 } from '../src/index'
 import type {
@@ -136,6 +137,141 @@ describe('WeaverseNextProvider hooks', () => {
 
     // Assert
     expect(html).toContain('Free shipping')
+  })
+})
+
+// ─── 1b. Root-owned theme provider ────────────────────────────────────
+
+describe('WeaverseNextRootProvider', () => {
+  it('should_expose_themeSettings_at_root_without_a_route_provider', () => {
+    // Arrange
+    function Probe() {
+      let theme = useThemeSettings<{ topbarText: string }>()
+      return <span>{theme.topbarText}</span>
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextRootProvider
+        initialThemeSettings={{ topbarText: 'Root free shipping' }}
+      >
+        <Probe />
+      </WeaverseNextRootProvider>
+    )
+
+    // Assert
+    expect(html).toContain('Root free shipping')
+  })
+
+  it('should_render_root_ssr_value_even_when_route_provider_carries_pending_theme_data', () => {
+    // Arrange — route provider supplies its own theme data on top of root's,
+    // but the merge into the root store runs in a client-only effect (not
+    // during render), so it never runs under `renderToStaticMarkup`.
+    let client = makeClient({ themeSettings: { topbarText: 'Route' } })
+
+    function Probe() {
+      let theme = useThemeSettings<{ topbarText: string }>()
+      return <span>{theme.topbarText}</span>
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextRootProvider initialThemeSettings={{ topbarText: 'Root' }}>
+        <WeaverseNextProvider client={client}>
+          <Probe />
+        </WeaverseNextProvider>
+      </WeaverseNextRootProvider>
+    )
+
+    // Assert — root's initial theme is authoritative on SSR; the route
+    // override applies after client mount, not as a render-phase mutation.
+    expect(html).toContain('Root')
+    expect(html).not.toContain('Route')
+  })
+
+  it('should_keep_root_only_settings_when_route_provider_has_no_explicit_theme_data', () => {
+    // Arrange — route provider carries page data but no theme override.
+    let client = makeClient()
+
+    function Probe() {
+      let theme = useThemeSettings<{ topbarText: string }>()
+      return <span>{theme.topbarText}</span>
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextRootProvider
+        initialThemeSettings={{ topbarText: 'Root only' }}
+      >
+        <WeaverseNextProvider client={client}>
+          <Probe />
+        </WeaverseNextProvider>
+      </WeaverseNextRootProvider>
+    )
+
+    // Assert
+    expect(html).toContain('Root only')
+  })
+
+  it('should_share_the_same_theme_store_between_root_and_the_page_renderer', () => {
+    // Arrange — a page-tree component reads useThemeSettings() through the
+    // renderer/runtime path; it must observe the root store's value, proving
+    // that path threads the same store instance instead of falling back to
+    // an empty per-route store. No route-level `themeSettings` here, so this
+    // is unaffected by the client-only route-merge effect.
+    let ThemeAware = () => {
+      let theme = useThemeSettings<{ topbarText: string }>()
+      return <div>{theme.topbarText}</div>
+    }
+    let themeAwareComponent = {
+      default: ThemeAware,
+      schema: createSchema({ type: 'theme-aware', title: 'Theme aware' }),
+    }
+    let client = createWeaverseNextClient({
+      projectId: 'proj-test',
+      components: [themeAwareComponent],
+    })
+    client.data = {
+      page: {
+        id: 'page-theme-aware',
+        rootId: 'theme-aware-root',
+        items: [{ id: 'theme-aware-root', type: 'theme-aware' }],
+      },
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextRootProvider
+        initialThemeSettings={{ topbarText: 'Root shared' }}
+      >
+        <WeaverseNextProvider client={client}>
+          <WeaverseNextRenderer />
+        </WeaverseNextProvider>
+      </WeaverseNextRootProvider>
+    )
+
+    // Assert — the page renderer observes the same root store instance.
+    expect(html).toContain('Root shared')
+  })
+
+  it('should_keep_backward_compatible_behavior_when_no_root_provider_is_mounted', () => {
+    // Arrange — no WeaverseNextRootProvider anywhere in the tree.
+    let client = makeClient({ themeSettings: { topbarText: 'Standalone' } })
+
+    function Probe() {
+      let theme = useThemeSettings<{ topbarText: string }>()
+      return <span>{theme.topbarText}</span>
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextProvider client={client}>
+        <Probe />
+      </WeaverseNextProvider>
+    )
+
+    // Assert
+    expect(html).toContain('Standalone')
   })
 })
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -41,6 +41,11 @@ export {
   revalidateWeaverseNextItem,
 } from './revalidate-item'
 export {
+  type WeaverseNextRootContextValue,
+  WeaverseNextRootProvider,
+  type WeaverseNextRootProviderProps,
+} from './root-provider'
+export {
   bindWeaverseNextStudioRuntime,
   createWeaverseNextRuntime,
   WeaverseNextRuntime,

--- a/packages/next/src/provider.tsx
+++ b/packages/next/src/provider.tsx
@@ -1,6 +1,14 @@
 'use client'
 
-import { createContext, type ReactNode, useMemo } from 'react'
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
+import { WeaverseNextRootContext } from './root-provider'
 import { createWeaverseNextThemeSettingsStore } from './theme-settings-store'
 import type {
   WeaverseNextClient,
@@ -64,18 +72,58 @@ export interface WeaverseNextProviderProps {
  */
 export function WeaverseNextProvider(props: WeaverseNextProviderProps) {
   let { children, client, rootData, pageData, commerce, themeSettings } = props
+  let rootContext = useContext(WeaverseNextRootContext)
 
   let themeSettingsValue =
     themeSettings ?? client?.themeSettings ?? EMPTY_THEME_SETTINGS
-  let themeSettingsStore = useMemo(
-    () =>
-      createWeaverseNextThemeSettingsStore({
-        schema: client?.themeSchema,
-        settings: themeSettingsValue,
-      }),
-    [client?.themeSchema, themeSettingsValue]
-  )
 
+  // Fallback store for apps that don't mount `WeaverseNextRootProvider`. Not
+  // created at all when a root store is present, so exactly one
+  // `WeaverseNextThemeSettingsStore` exists per page load either way.
+  let ownThemeSettingsStore = useMemo(() => {
+    if (rootContext) {
+      return null
+    }
+    return createWeaverseNextThemeSettingsStore({
+      schema: client?.themeSchema,
+      settings: themeSettingsValue,
+    })
+  }, [rootContext, client?.themeSchema, themeSettingsValue])
+
+  let themeSettingsStore =
+    rootContext?.themeSettingsStore ??
+    (ownThemeSettingsStore as WeaverseNextThemeSettingsStore)
+
+  // When adopting the root store, route-supplied theme data augments it in
+  // place (merge), never replaces it — Studio and root `Header`/`Footer` must
+  // keep observing the same instance. Guarded so a stable `themeSettingsValue`
+  // across re-renders doesn't re-merge/re-notify every render.
+  //
+  // This runs in an effect, not render: mutating a store shared outside this
+  // component's subtree is a side effect, and render functions must stay
+  // pure under concurrent React (retried/discarded renders, StrictMode
+  // double-invocation). The root's initial theme is authoritative for SSR;
+  // a route's `themeSettings`/`client.themeSettings` override applies after
+  // client mount instead of racing a render-phase store mutation. Apps that
+  // don't mount `WeaverseNextRootProvider` are unaffected — `themeSettings`
+  // still renders synchronously on SSR via `ownThemeSettingsStore` below.
+  let mergedIntoRootRef = useRef<Record<string, unknown> | undefined>(undefined)
+  useEffect(() => {
+    if (
+      rootContext &&
+      themeSettingsValue !== EMPTY_THEME_SETTINGS &&
+      mergedIntoRootRef.current !== themeSettingsValue
+    ) {
+      rootContext.themeSettingsStore.updateThemeSettings(themeSettingsValue)
+      mergedIntoRootRef.current = themeSettingsValue
+    }
+  }, [rootContext, themeSettingsValue])
+
+  // Do not depend on `themeSettingsValue` here. In fallback mode it is already
+  // represented by a new `themeSettingsStore`; in root-adoption mode the
+  // post-mount merge effect notifies `useThemeSettings()` subscribers. Including
+  // it would recreate this context with a stale root snapshot before the effect
+  // fires, causing an avoidable extra render.
   let value = useMemo<WeaverseNextContextValue>(
     () => ({
       client,

--- a/packages/next/src/root-provider.tsx
+++ b/packages/next/src/root-provider.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import {
+  createContext,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
+import { WeaverseNextContext, type WeaverseNextContextValue } from './provider'
+import { createWeaverseNextThemeSettingsStore } from './theme-settings-store'
+import type { WeaverseNextThemeSettingsStore } from './types'
+
+export interface WeaverseNextRootContextValue {
+  themeSettingsStore: WeaverseNextThemeSettingsStore
+}
+
+/**
+ * Ambient root-scoped context. Route-level `WeaverseNextProvider` reads this to
+ * adopt the shared theme settings store instead of creating its own.
+ */
+export const WeaverseNextRootContext =
+  createContext<WeaverseNextRootContextValue | null>(null)
+
+export interface WeaverseNextRootProviderProps {
+  children: ReactNode
+  /** Root-loaded theme settings (published-mode fetch, no design-mode context). */
+  initialThemeSettings?: Record<string, unknown>
+  publicEnv?: Record<string, string | undefined>
+  themeSchema?: unknown
+}
+
+/**
+ * Root-scoped client boundary that owns the single `WeaverseNextThemeSettingsStore`
+ * for the whole app session, matching Hydrogen's `withWeaverse()` root store.
+ * Mount once in `app/layout.tsx`, above `Header`/`Footer`/global modules and any
+ * route-level `WeaverseNextProvider`.
+ *
+ * Also renders `WeaverseNextContext` with a minimal value so `useThemeSettings()`
+ * works for components mounted directly under this provider, even without a
+ * route-level `WeaverseNextProvider` above them.
+ *
+ * @example
+ * ```tsx
+ * <WeaverseNextRootProvider initialThemeSettings={theme.theme} themeSchema={theme.schema}>
+ *   <Header />
+ *   {children}
+ *   <Footer />
+ * </WeaverseNextRootProvider>
+ * ```
+ */
+export function WeaverseNextRootProvider(props: WeaverseNextRootProviderProps) {
+  let { children, initialThemeSettings, themeSchema, publicEnv } = props
+
+  // `useRef`, not `useMemo`: a parent re-render must never replace this store —
+  // it is the single instance Studio's `updateThemeSettings()` mutates in place.
+  let storeRef = useRef<WeaverseNextThemeSettingsStore | null>(null)
+  if (!storeRef.current) {
+    storeRef.current = createWeaverseNextThemeSettingsStore({
+      publicEnv,
+      schema: themeSchema,
+      settings: initialThemeSettings,
+    })
+  }
+  let themeSettingsStore = storeRef.current
+
+  // If `initialThemeSettings` changes after mount (e.g. root revalidation),
+  // update the existing store in place instead of replacing it. This is an
+  // effect because external store updates are side effects; the initial render
+  // is already seeded synchronously by store construction above.
+  let appliedThemeSettingsRef = useRef(initialThemeSettings)
+  useEffect(() => {
+    if (
+      initialThemeSettings &&
+      appliedThemeSettingsRef.current !== initialThemeSettings
+    ) {
+      themeSettingsStore.updateThemeSettings(initialThemeSettings)
+      appliedThemeSettingsRef.current = initialThemeSettings
+    }
+  }, [initialThemeSettings, themeSettingsStore])
+
+  // `themeSettingsStore` is `useRef`-stable, so memoizing on it (rather than
+  // recreating these plain objects every render) keeps `useThemeSettings()`
+  // consumers (Header, Footer, ...) from re-rendering on every root re-render.
+  let rootContextValue = useMemo<WeaverseNextRootContextValue>(
+    () => ({ themeSettingsStore }),
+    [themeSettingsStore]
+  )
+  let contextValue = useMemo<WeaverseNextContextValue>(
+    () => ({
+      themeSettings: themeSettingsStore.getSnapshot(),
+      themeSettingsStore,
+    }),
+    [themeSettingsStore]
+  )
+
+  return (
+    <WeaverseNextRootContext.Provider value={rootContextValue}>
+      <WeaverseNextContext.Provider value={contextValue}>
+        {children}
+      </WeaverseNextContext.Provider>
+    </WeaverseNextRootContext.Provider>
+  )
+}


### PR DESCRIPTION
Refs Weaverse/builder#2659.

Adds the root-owned theme settings store needed for Next global modules to mirror Hydrogen's `withWeaverse()` behavior.

- Add `WeaverseNextRootProvider` for `app/layout.tsx`, seeded by root-loaded published-mode theme settings.
- Make route-level `WeaverseNextProvider` adopt the ambient root store instead of creating a second store; fallback behavior is unchanged when no root provider is mounted.
- Keep page runtime/renderer route-scoped while sharing the same theme store with root modules and Studio updates.
- Document the root provider pattern and add package tests.

Verification:
- `pnpm --filter @weaverse/next test -- __tests__/next-adapter.test.tsx`
- `pnpm --filter @weaverse/next typecheck`
- `pnpm --filter @weaverse/next build`
- `pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error`
- `git diff --check`

Note: POC/starter wiring is intentionally next slice; this PR is SDK package-level coverage.