### PR TITLE
Add Next page assignment save parity

### DIFF
--- a/.specs/2026-06-21--next-studio-bridge/claude-handoff-next-page-assignment-save-parity.md
+++ b/.specs/2026-06-21--next-studio-bridge/claude-handoff-next-page-assignment-save-parity.md
@@ -1,0 +1,84 @@
+# Claude handoff — Next pageAssignment / Studio save payload parity
+
+## Repo / branch
+
+- Repo: `/Users/hta218/Documents/work/workspace/weaverse`
+- Branch: `feat/next-page-assignment-save-parity`
+- Base: `main` at `0780667b Release @weaverse/next 0.1.0-alpha.6`
+- Tracker: https://github.com/Weaverse/builder/issues/2659
+
+## Context
+
+We are continuing Next Productionization Epic 2663. Already shipped:
+
+- dedicated Next Studio bridge `/static/studio/next/*`
+- low-risk helper parity
+- error/404 Studio script loading
+- root-scoped theme settings provider (`WeaverseNextRootProvider`), published in `@weaverse/next@0.1.0-alpha.6`
+- POC root-provider PR merged and manually smoke-tested by Leo
+
+Next requested slice: **pageAssignment / Studio save payload parity**.
+
+Hydrogen reference path:
+
+- `packages/hydrogen/src/weaverse-client.ts`: `loadPage()` preserves `project`, `page`, `pageAssignment` from `/api/public/project`.
+- `packages/hydrogen/src/WeaverseHydrogenRoot.tsx`: runtime internal carries `{ project, pageAssignment }`.
+- Builder Studio uses `window.__weaverses` and `studio/utils/data.ts::generatePageData()` to build `{ page, pageAssignment }` for save.
+- Builder save schema expects `pageAssignment` with `{ projectId, type, locale, handle }`; backend may include `meta` on the wire but it is not saved directly.
+- Builder fallback helper: `studio/utils/page-meta.ts::resolveFallbackPageMeta()` treats `fallback_page_*` ids specially and names the new page from `pageAssignment.handle`.
+
+Current Next state:
+
+- `packages/next/src/server/server-client.ts::_createLoaderData()` copies `payload.pageAssignment` as a loose record.
+- `packages/next/src/runtime.ts` sets/updates `runtime.internal.pageAssignment` from loader data.
+- `packages/next/src/types.ts` currently types `pageAssignment` / `internal.pageAssignment` as loose `Record<string, unknown>` / `unknown`.
+- Existing tests cover that runtime internal receives `pageAssignment` at a basic level, but not save-compatible shape, locale normalization, or inherited `meta` preservation.
+
+## Goal
+
+Make the Next package’s page assignment contract explicit and test-backed so the Builder Studio save pipeline receives the same page assignment payload shape it expects from Hydrogen.
+
+Expected implementation shape:
+
+1. Add an explicit exported type for Next page assignments, e.g. `WeaverseNextPageAssignment`, with at least:
+   - `projectId: string`
+   - `type: PageType | string` (or equivalent that fits existing package typing)
+   - `locale: string`
+   - `handle: string`
+   - optional `meta` for inherited/fallback metadata, preserving unknown fields safely
+2. Add a small normalizer/helper if useful, e.g. `normalizeWeaverseNextPageAssignment(input)`:
+   - returns `undefined` for missing/malformed assignments rather than fabricating one
+   - normalizes `locale: null | undefined` to `''`
+   - preserves `meta` when it is an object
+   - keeps the payload save-compatible and framework-neutral
+3. Use that normalizer in `createWeaverseNextServerClient().loadPage()` / `_createLoaderData()`.
+4. Tighten `WeaverseNextLoaderData.pageAssignment` and `WeaverseNextRuntimeInternal.pageAssignment` types to the explicit type.
+5. Add tests proving:
+   - `loadPage()` preserves a full save-compatible assignment, including `projectId`, `type`, `locale`, `handle`, and inherited `meta`.
+   - `loadPage()` normalizes nullish locale to `''`.
+   - `WeaverseNextRuntime` exposes that page assignment on `runtime.internal.pageAssignment`.
+   - Reusing a design-mode runtime on navigation/request-key changes updates `runtime.internal.pageAssignment` to the latest loader payload.
+   - Existing fallback page id prefix (`fallback_page_*`) remains unchanged if tests touch fallback data.
+6. Update README/spec work-log concisely with the save payload contract and verification.
+
+## Non-goals
+
+- Do not touch Builder save endpoint or database writes in this SDK PR unless a test reveals an SDK-caused incompatibility.
+- Do not implement translation/static-text sidecar in this slice.
+- Do not change global sections, multi-runtime selection, markets/i18n cache strategy, or redirect helpers.
+- Do not publish npm; Hermes will verify and decide next step.
+- Leave changes uncommitted; Hermes will review, run checks, commit, push, and open the PR.
+
+## Verification commands
+
+Run at least:
+
+```bash
+pnpm --filter @weaverse/next test -- __tests__/next-server.test.tsx __tests__/next-adapter.test.tsx
+pnpm --filter @weaverse/next typecheck
+pnpm --filter @weaverse/next build
+pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error
+git diff --check
+```
+
+Report exact commands and results. If you hit an unrelated/pre-existing failure, include the failure and continue with the narrow checks where possible.

--- a/.specs/2026-06-21--next-studio-bridge/work-logs.md
+++ b/.specs/2026-06-21--next-studio-bridge/work-logs.md
@@ -276,3 +276,40 @@ git diff --check
 ### Remaining risk
 
 - The client-only merge effect (route theme data landing in the root store after mount, and root `Header`/`Footer` re-rendering from it) is unverified by an automated test for the reason above — still an open item for a future jsdom-enabled test pass or POC-level manual check.
+
+## 2026-07-10 — pageAssignment / Studio save payload parity
+
+Slice branch: `feat/next-page-assignment-save-parity`
+
+### Scope
+
+- Added an explicit `WeaverseNextPageAssignment` type for the Builder Studio save contract (`projectId`, `type`, `locale`, `handle`, optional inherited/fallback `meta`).
+- Normalized raw `/api/public/project` assignments in `createWeaverseNextServerClient().loadPage()`:
+  - missing/malformed assignments remain `undefined` instead of being fabricated;
+  - nullish `locale` becomes `''`;
+  - object `meta` is preserved for inherited/fallback diagnostics.
+- Tightened `WeaverseNextLoaderData.pageAssignment` and `WeaverseNextRuntimeInternal.pageAssignment` to the explicit type.
+- Added tests proving full save-compatible assignment preservation, null-locale normalization, runtime internal exposure, and runtime reuse updating the assignment after navigation/revalidation.
+
+### Verification
+
+```bash
+pnpm --filter @weaverse/next test -- __tests__/next-server.test.tsx __tests__/next-adapter.test.tsx
+# 5 files, 83 tests passed
+
+pnpm --filter @weaverse/next typecheck
+# passed
+
+pnpm --filter @weaverse/next build
+# passed
+
+pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error
+# passed
+
+git diff --check
+# passed
+```
+
+### Notes
+
+Claude started the SDK implementation from the handoff and timed out after touching the package source. Hermes completed the missing tests/work-log and ran verification. No Builder database/save endpoint changes were needed for this package-level contract slice.

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -1007,7 +1007,13 @@ describe('Studio runtime contract', () => {
     })
     let data = {
       ...makePageData(),
-      pageAssignment: { type: 'INDEX' },
+      pageAssignment: {
+        projectId: 'proj-test',
+        type: 'INDEX',
+        locale: '',
+        handle: '',
+        meta: { inherited: false, sourceProjectId: 'proj-test', depth: 0 },
+      },
       project: { id: 'project-record' },
     }
 
@@ -1024,7 +1030,13 @@ describe('Studio runtime contract', () => {
       queries: { isDesignMode: true },
     })
     expect(runtime.internal.project).toEqual({ id: 'project-record' })
-    expect(runtime.internal.pageAssignment).toEqual({ type: 'INDEX' })
+    expect(runtime.internal.pageAssignment).toEqual({
+      projectId: 'proj-test',
+      type: 'INDEX',
+      locale: '',
+      handle: '',
+      meta: { inherited: false, sourceProjectId: 'proj-test', depth: 0 },
+    })
     expect(runtime.internal.themeSettingsStore?.settings).toEqual({
       color: 'blue',
     })
@@ -1046,10 +1058,27 @@ describe('Studio runtime contract', () => {
     let client = makeClient({
       requestContext: { isDesignMode: true, pathname: '/' },
     })
-    let runtime = createWeaverseNextRuntime({ client, data: makePageData() })
+    let initialData = {
+      ...makePageData(),
+      pageAssignment: {
+        projectId: 'proj-test',
+        type: 'INDEX',
+        locale: '',
+        handle: '',
+      },
+    }
+    let runtime = createWeaverseNextRuntime({ client, data: initialData })
     bindWeaverseNextStudioRuntime(runtime)
+    let nextPageAssignment = {
+      projectId: 'proj-test',
+      type: 'COLLECTION',
+      locale: 'en-us',
+      handle: 'sale',
+      meta: { inherited: true, sourceProjectId: 'proj-parent', depth: 1 },
+    }
     let nextData = {
       ...makePageData(),
+      pageAssignment: nextPageAssignment,
       page: {
         ...makePageData().page,
         items: [
@@ -1066,6 +1095,7 @@ describe('Studio runtime contract', () => {
     // Assert — refreshStudio must receive the FRESH server payload, not the
     // (deliberately untouched) design-mode live tree on `runtime.data`.
     expect(reusedRuntime).toBe(runtime)
+    expect(reusedRuntime.internal.pageAssignment).toEqual(nextPageAssignment)
     expect(init).toHaveBeenCalledTimes(1)
     expect(refreshStudio).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/next/__tests__/next-server.test.tsx
+++ b/packages/next/__tests__/next-server.test.tsx
@@ -47,7 +47,12 @@ function makePagePayload() {
       items: [{ id: 'item-root', type: 'hero', data: { heading: 'Hi' } }],
     },
     project: { id: 'project-record', name: 'Shop', weaverseShopId: 'shop-1' },
-    pageAssignment: { type: 'INDEX' },
+    pageAssignment: {
+      projectId: 'proj-123',
+      type: 'INDEX',
+      locale: '',
+      handle: '',
+    },
   }
 }
 
@@ -177,6 +182,72 @@ describe('createWeaverseNextServerClient loadPage', () => {
     expect(url.searchParams.get('weaverseDraftItem')).toBe(draftItem)
     expect(url.searchParams.has('_rsc')).toBe(false)
     expect(url.searchParams.has('utm_source')).toBe(false)
+  })
+
+  it('should_return_save_compatible_pageAssignment_with_inherited_meta', async () => {
+    let fetchMock = makeFetch({
+      ...makePagePayload(),
+      pageAssignment: {
+        projectId: 'proj-123',
+        type: 'COLLECTION',
+        locale: 'en-us',
+        handle: 'sale',
+        meta: {
+          inherited: true,
+          sourceProjectId: 'parent-project',
+          depth: 1,
+          fallbackReason: 'parent-default',
+        },
+      },
+    })
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      fetch: fetchMock,
+      requestContext: { url: 'https://shop.example/collections/sale' },
+    })
+
+    let data = await client.loadPage({ type: 'COLLECTION', handle: 'sale' })
+
+    expect(data?.pageAssignment).toEqual({
+      projectId: 'proj-123',
+      type: 'COLLECTION',
+      locale: 'en-us',
+      handle: 'sale',
+      meta: {
+        inherited: true,
+        sourceProjectId: 'parent-project',
+        depth: 1,
+        fallbackReason: 'parent-default',
+      },
+    })
+  })
+
+  it('should_normalize_nullish_pageAssignment_locale_to_empty_string', async () => {
+    let fetchMock = makeFetch({
+      ...makePagePayload(),
+      pageAssignment: {
+        projectId: 'proj-123',
+        type: 'PAGE',
+        locale: null,
+        handle: '/abcxyz',
+      },
+    })
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      fetch: fetchMock,
+      requestContext: { url: 'https://shop.example/abcxyz' },
+    })
+
+    let data = await client.loadPage({ type: 'PAGE', handle: '/abcxyz' })
+
+    expect(data?.pageAssignment).toEqual({
+      projectId: 'proj-123',
+      type: 'PAGE',
+      locale: '',
+      handle: '/abcxyz',
+    })
   })
 
   it('should_use_no_store_cache_in_design_mode', async () => {

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -96,6 +96,7 @@ export type {
   WeaverseNextI18n,
   WeaverseNextLoaderData,
   WeaverseNextLoadPageInput,
+  WeaverseNextPageAssignment,
   WeaverseNextPageData,
   WeaverseNextRequestContext,
   WeaverseNextRequestInfo,

--- a/packages/next/src/server/server-client.ts
+++ b/packages/next/src/server/server-client.ts
@@ -13,6 +13,7 @@ import type {
   WeaverseNextFetchOptions,
   WeaverseNextLoaderData,
   WeaverseNextLoadPageInput,
+  WeaverseNextPageAssignment,
   WeaverseNextPageData,
   WeaverseNextProjectId,
   WeaverseNextRequestContext,
@@ -63,6 +64,43 @@ function generateUuid(): string {
     return crypto.randomUUID()
   }
   return `id-${Math.random().toString(RANDOM_ID_RADIX).slice(RANDOM_ID_SLICE_START)}`
+}
+
+/**
+ * Normalize the raw `pageAssignment` from `/api/public/project` into a
+ * save-compatible {@link WeaverseNextPageAssignment} so the Builder Studio save
+ * pipeline receives the same shape it gets from Hydrogen. Returns `undefined`
+ * for a missing or malformed assignment (rather than fabricating one), requires
+ * string `projectId`/`type`/`handle`, coerces a nullish `locale` to `''`, and
+ * preserves an object `meta` untouched.
+ */
+function normalizeWeaverseNextPageAssignment(
+  input: unknown
+): WeaverseNextPageAssignment | undefined {
+  if (!input || typeof input !== 'object') {
+    return
+  }
+  let { projectId, type, handle, locale, meta } = input as Record<
+    string,
+    unknown
+  >
+  if (
+    typeof projectId !== 'string' ||
+    typeof type !== 'string' ||
+    typeof handle !== 'string'
+  ) {
+    return
+  }
+  let normalized: WeaverseNextPageAssignment = {
+    projectId,
+    type,
+    handle,
+    locale: typeof locale === 'string' ? locale : '',
+  }
+  if (meta && typeof meta === 'object') {
+    normalized.meta = meta as WeaverseNextPageAssignment['meta']
+  }
+  return normalized
 }
 
 /**
@@ -451,9 +489,9 @@ class NextServerClient implements WeaverseNextServerClient {
     this._assertNoPageError(payload)
     let page = payload.page as WeaverseNextPageData | undefined
     let project = payload.project as WeaverseNextLoaderData['project']
-    let pageAssignment = payload.pageAssignment as
-      | WeaverseNextLoaderData['pageAssignment']
-      | undefined
+    let pageAssignment = normalizeWeaverseNextPageAssignment(
+      payload.pageAssignment
+    )
 
     page ??= this._generateFallbackPage(
       '<div style="text-align: center;">Please add new section to start.</div>'

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -22,12 +22,34 @@ export interface WeaverseNextThemeSettingsStore {
   updateThemeSettings: (next: Record<string, unknown>) => void
 }
 
+/**
+ * Page assignment payload returned by `/api/public/project` and preserved on
+ * loader data so the Builder Studio save pipeline receives the same shape it
+ * gets from Hydrogen (`{ projectId, type, locale, handle }`, plus optional
+ * inherited/fallback `meta`). Kept framework-neutral: `type` accepts a known
+ * {@link PageType} or any string, and `meta` preserves inherited/fallback
+ * metadata (unknown fields included) without asserting a strict shape.
+ */
+export interface WeaverseNextPageAssignment {
+  handle: string
+  locale: string
+  /** Inherited/fallback page metadata; unknown fields preserved as-is. */
+  meta?: {
+    depth?: number
+    inherited?: boolean
+    sourceProjectId?: string
+    [key: string]: unknown
+  }
+  projectId: string
+  type: PageType | string
+}
+
 export interface WeaverseNextRuntimeInternal {
   navigate?: (
     to: string,
     options?: { preventScrollReset?: boolean } | Record<string, unknown>
   ) => void
-  pageAssignment?: unknown
+  pageAssignment?: WeaverseNextPageAssignment
   project?: unknown
   revalidate?: (options?: unknown) => Promise<void> | void
   /**
@@ -133,7 +155,7 @@ export interface WeaverseNextPageData {
 export interface WeaverseNextLoaderData {
   configs?: Record<string, unknown>
   page: WeaverseNextPageData
-  pageAssignment?: Record<string, unknown>
+  pageAssignment?: WeaverseNextPageAssignment
   project?: Record<string, unknown>
   [key: string]: unknown
 }


### PR DESCRIPTION
## Summary
- Add an explicit `WeaverseNextPageAssignment` type and export it from `@weaverse/next`.
- Normalize `/api/public/project` page assignments in the Next server client before they reach loader/runtime data.
- Preserve save-compatible fields (`projectId`, `type`, `locale`, `handle`) plus inherited/fallback `meta`; normalize nullish locale to `''`; drop malformed assignments instead of fabricating one.
- Add tests for server loader payload shape and Studio runtime reuse updates.
- Add the Claude handoff + work-log entry under the existing Next Studio bridge spec.

## Verification
- `pnpm --filter @weaverse/next test -- __tests__/next-server.test.tsx __tests__/next-adapter.test.tsx`
- `pnpm --filter @weaverse/next typecheck`
- `pnpm --filter @weaverse/next build`
- `pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error`
- `git diff --check`
- `autoreview-copilot --mode local` — clean, no accepted/actionable findings

## Notes
Claude started the SDK implementation from the handoff; Hermes completed the missing tests/work-log, reviewed the diff, and ran verification.

Tracker: Weaverse/builder#2659
