### PR TITLE
Add Next translation static text foundation

### DIFF
--- a/.specs/2026-06-21--next-studio-bridge/claude-handoff-next-translation-foundation.md
+++ b/.specs/2026-06-21--next-studio-bridge/claude-handoff-next-translation-foundation.md
@@ -1,0 +1,105 @@
+# Claude handoff — Next translation/static-text foundation parity
+
+## Repo / branch
+
+- Repo: `/Users/hta218/Documents/work/workspace/weaverse`
+- Branch: `feat/next-translation-sidecar-foundation`
+- Base: `main` at `0b303b5b Test Next multi-runtime selection parity`
+- Tracker: https://github.com/Weaverse/builder/issues/2659
+
+## Context
+
+Continuing Next Productionization Epic 2663. Recently landed:
+
+- `@weaverse/next@0.1.0-alpha.7`: pageAssignment/save payload parity.
+- PR #487: tests-only multi-runtime/nested instance registry parity.
+
+Next parity area is **translation/static-text sidecar**. It is broad, so this first PR should be a narrow **foundation** slice: add the static text translation provider/store/hooks and wire them into the Next root/provider/runtime enough for Builder static-text Studio updates to reach the runtime. Do not try to finish item-level translation sidecar in this PR unless the cleanest implementation falls out naturally.
+
+## Hydrogen reference
+
+Important Hydrogen files already audited:
+
+- `packages/hydrogen/src/hooks/translation-context.tsx`
+  - exports `TranslationProvider`, `useTranslation`, deprecated `useThemeText`, `createTranslate`, `getNestedKey`, `interpolate`.
+  - priority: external `t` > design overrides (`TranslationStore`) > merchantOverrides > staticContent > key.
+- `packages/hydrogen/src/utils/translation-store.ts`
+  - mutable `TranslationStore` / deprecated `ThemeTextStore`, with `setOverrides`, `updateOverrides`, `subscribe`, snapshots.
+- `packages/hydrogen/src/WeaverseHydrogenRoot.tsx::withWeaverse()`
+  - root wrapper creates a single `TranslationStore` and wraps app in `TranslationProvider` with root-loaded `staticContent` and `merchantOverrides`.
+- `packages/hydrogen/src/utils/use-studio.ts::useStudio()`
+  - attaches `translationStore`, deprecated `themeTextStore`, and `merchantOverrides` to `weaverse.internal` so Builder `updateStaticText()` can mutate live design overrides.
+- `packages/hydrogen/src/weaverse-client.ts::loadThemeSettings()`
+  - always includes `staticContent` from `themeSchema.i18n.staticContent` and locale-specific `merchantOverrides` from the API.
+
+Builder Studio expectations:
+
+- `builder/studio/rpc/methods.ts::updateStaticText()` reads `this.studio.weaverse.internal.themeTextStore` and calls `updateOverrides(overrides)` for live static text preview, then accumulates changes for save.
+- `builder/studio/index.ts::restoreStaticTextDrafts()` reads `internal.themeTextStore` and calls `setOverrides(...)` during init.
+- `builder/studio/index.ts::syncDataWithEditor()` sends `staticTranslationOverrides: merchantOverrides || undefined`.
+
+Current Next state:
+
+- `packages/next/src/types.ts::WeaverseNextThemeSettingsResponse` already has `staticContent?: Record<string, unknown>` and `merchantOverrides?: Record<string, unknown>`.
+- `packages/next/src/server/server-client.ts::loadThemeSettings()` needs audit: it likely returns remote theme response but may not inject `themeSchema.i18n.staticContent` like Hydrogen does.
+- `packages/next/src/root-provider.tsx` owns theme settings store only.
+- `packages/next/src/provider.tsx` route provider adopts root theme store only.
+- `packages/next/src/runtime.ts` stubs translation sidecar methods and does not attach static text stores/overrides to `runtime.internal`.
+- No `useTranslation` / `useThemeText` exports in `@weaverse/next` yet.
+
+## Goal: first narrow foundation slice
+
+Implement static text translation foundation parity for `@weaverse/next`:
+
+1. Add Next-owned translation context/store modules, porting Hydrogen behavior with Next naming and compatibility aliases:
+   - `TranslationStore`, deprecated `ThemeTextStore`
+   - `TranslationProvider`, deprecated `ThemeTextProvider`
+   - `useTranslation`, deprecated `useThemeText`
+   - helpers `createTranslate`, `getNestedKey`, `interpolate`
+   - keep behavior aligned with Hydrogen priority chain and interpolation.
+2. Wire root provider ownership:
+   - `WeaverseNextRootProvider` should create one stable `TranslationStore` ref, like it does for theme settings.
+   - Add props for `staticContent`, `merchantOverrides`, and optional external `t` if needed.
+   - Wrap children in `TranslationProvider` so global modules can call `useTranslation()` / `useThemeText()`.
+3. Wire route/runtime adoption enough for Builder static text updates:
+   - Add translation store and merchant overrides to root context value.
+   - Let `WeaverseNextProvider` adopt the ambient root translation store/merchantOverrides (fallback creates its own store when no root provider exists).
+   - Extend `WeaverseNextContextValue` / runtime config/internal types as needed.
+   - `WeaverseNextRenderer` should pass translation store / merchantOverrides into `createWeaverseNextRuntime()`.
+   - `WeaverseNextRuntime.internal` should include `translationStore`, deprecated `themeTextStore`, and `merchantOverrides` so Builder's existing static-text RPC works with Next just like Hydrogen.
+4. Ensure `loadThemeSettings()` mirrors Hydrogen static content behavior:
+   - If `themeSchema.i18n.staticContent` exists, include it in the returned theme settings response.
+   - Preserve returned `merchantOverrides` if present; do not invent a fetch endpoint unless current server client already has one or tests can mock returned data.
+5. Export public APIs from `packages/next/src/index.ts`.
+6. Tests:
+   - `TranslationStore`: `setOverrides`, `updateOverrides`, subscribe/snapshot behavior.
+   - `createTranslate`: priority chain + interpolation + nested merchant/static lookup + design override exact-key priority.
+   - `TranslationProvider`/`useTranslation`: hook returns translated values inside provider and throws outside provider.
+   - `WeaverseNextRootProvider`: root/global child can call `useTranslation()` using `staticContent` and live store overrides.
+   - Runtime bridge: a runtime created through provider/renderer or direct `createWeaverseNextRuntime` config exposes `internal.themeTextStore`/`translationStore` and `merchantOverrides`; updating the store changes `useTranslation()` consumers in tests where feasible.
+   - Server theme settings: `loadThemeSettings()` includes `themeSchema.i18n.staticContent` in response.
+7. Update `packages/next/README.md` only if there is an obvious public API snippet; otherwise work-log is enough.
+8. Append a concise work-log entry to `.specs/2026-06-21--next-studio-bridge/work-logs.md`.
+
+## Non-goals / guardrails
+
+- Do **not** touch Builder in this PR.
+- Do **not** implement full item-level translation sidecar unless it is very small and required by static text wiring. In particular, do not rewrite `WeaverseNextItem.getSnapShot()` / `updateTranslation()` unless you intentionally choose to include item translations and add tests.
+- Do **not** add a live network fetch for merchant overrides unless current server client already has the endpoint semantics. Preserve/propagate the response shape first.
+- Do **not** update POC or publish npm.
+- Keep old/deprecated Hydrogen names as compatibility aliases (`ThemeTextStore`, `useThemeText`, etc.) if you add new canonical names.
+- Leave changes uncommitted; Hermes will review, run checks, commit/push/open PR.
+
+## Verification commands
+
+Run at least:
+
+```bash
+pnpm --filter @weaverse/next test -- __tests__/next-adapter.test.tsx __tests__/next-server.test.tsx
+pnpm --filter @weaverse/next typecheck
+pnpm --filter @weaverse/next build
+pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error
+git diff --check
+```
+
+Report exact commands/results. If the test runner ignores file args and runs all package tests, report actual count.

--- a/.specs/2026-06-21--next-studio-bridge/work-logs.md
+++ b/.specs/2026-06-21--next-studio-bridge/work-logs.md
@@ -396,3 +396,71 @@ git diff --check                        # clean (exit 0)
   co-located instances, confirm Builder edits the intended leaf) remains a
   manual/E2E step.
 - Changes left uncommitted per the handoff; Hermes commits/pushes after review.
+
+## 2026-07-10 — translation/static-text foundation parity
+
+Slice branch: `feat/next-translation-sidecar-foundation`
+Tracker: https://github.com/Weaverse/builder/issues/2659
+
+First narrow slice for the broader translation/static-text parity area. This intentionally focuses on **static text translation foundation** and Builder static-text bridge wiring; full item-level translation sidecar remains a later slice.
+
+### Scope
+
+- Added Next-owned `TranslationStore` / deprecated `ThemeTextStore` aliases matching Hydrogen's mutable static-text override store.
+- Added `TranslationProvider`, `useTranslation`, deprecated `useThemeText`, `createTranslate`, `getNestedKey`, and `interpolate` with the Hydrogen priority chain:
+  1. external `t`
+  2. live design overrides from `TranslationStore`
+  3. locale `merchantOverrides`
+  4. theme `staticContent`
+  5. key fallback
+- Wired `WeaverseNextRootProvider` to own one stable root translation store, plus `staticContent`, `merchantOverrides`, and optional external `t`.
+- Wired route-level `WeaverseNextProvider` to adopt the root translation store/static content/merchant overrides, with a standalone fallback store when no root provider is mounted.
+- Wired `WeaverseNextRenderer` / `createWeaverseNextRuntime()` so the runtime exposes:
+  - `internal.translationStore`
+  - deprecated `internal.themeTextStore` (same instance, for Builder's existing `updateStaticText()` RPC)
+  - `internal.merchantOverrides`
+- Reused runtimes refresh translation store/merchant override wiring and clear stale merchant overrides when the latest loader/config has none.
+- Exported the new translation APIs from `@weaverse/next`.
+- Added/confirmed server theme-settings coverage for returned `merchantOverrides` and schema-derived `staticContent`.
+
+### Tests
+
+Added coverage in `packages/next/__tests__/next-adapter.test.tsx` and `next-server.test.tsx` for:
+
+- `TranslationStore` set/merge/subscribe behavior.
+- translation helper behavior: nested lookup, interpolation, priority chain, own-property design override safety.
+- `TranslationProvider` and `useTranslation`, including deprecated store alias and clear error outside provider.
+- `WeaverseNextRootProvider` exposing translations to root/global children.
+- route provider adopting the root translation store/static content.
+- page tree components rendered through `WeaverseNextRenderer` resolving static text.
+- runtime `internal.translationStore` / `themeTextStore` / `merchantOverrides` wiring and reuse refresh/clear behavior.
+- server `loadThemeSettings()` preserving API-provided `merchantOverrides` while injecting schema static content.
+
+### Non-scope
+
+- No Builder changes.
+- No item-level page translation sidecar yet (`translationMap`, translatable section fields, `updateTranslation()`, `getTranslationChanges()` remain a follow-up).
+- No POC update or npm publish in this PR until the code is reviewed/merged.
+
+### Verification
+
+```bash
+pnpm --filter @weaverse/next test -- __tests__/next-adapter.test.tsx __tests__/next-server.test.tsx
+# 5 files, 107 tests passed (test runner executed the whole package suite)
+
+pnpm --filter @weaverse/next typecheck
+# passed
+
+pnpm --filter @weaverse/next build
+# passed
+
+pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error
+# passed after formatting provider/root-provider
+
+git diff --check
+# passed
+```
+
+### Notes
+
+Claude implemented the initial source/tests from the handoff but timed out before closeout. Hermes reviewed the partial diff, fixed stale `merchantOverrides` clearing on runtime reuse, added regression coverage for that case, fixed the standalone-provider fallback `TranslationStore` to use `useRef` instead of `useMemo`, corrected translation priority docs, formatted, and ran verification.

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -7,12 +7,18 @@ import {
   bindWeaverseNextStudioRuntime,
   buildWeaverseNextRequestInfo,
   createSchema,
+  createTranslate,
   createWeaverseNextClient,
   createWeaverseNextRuntime,
   createWeaverseNextThemeSettingsStore,
+  getNestedKey,
+  interpolate,
   resolveWeaverseNextStudioScriptSrc,
   runWeaverseComponentLoaders,
+  TranslationProvider,
+  TranslationStore,
   useThemeSettings,
+  useTranslation,
   useWeaverseCommerce,
   useWeaversePageData,
   useWeaverseRootData,
@@ -28,6 +34,8 @@ import type {
 } from '../src/types'
 
 const OUTSIDE_PROVIDER_ERROR = /must be used inside a <WeaverseNextProvider>/
+const OUTSIDE_TRANSLATION_PROVIDER_ERROR =
+  /useTranslation must be used within <TranslationProvider>/
 const SRC_FILE_REGEX = /\.(ts|tsx)$/
 
 // ─── Fixtures ────────────────────────────────────────────────────────
@@ -1538,6 +1546,414 @@ describe('multi-runtime / nested instance selection', () => {
     expect(rootStoreA).not.toBe(rootStoreB)
     expect(rootStoreA._element).toBe(elementA)
     expect(rootStoreB._element).toBe(elementB)
+    vi.stubGlobal('window', previousWindow)
+  })
+})
+
+// ─── 8. Translation / static-text foundation ──────────────────────────
+
+describe('TranslationStore', () => {
+  it('should_replace_all_overrides_on_setOverrides_and_notify_subscribers', () => {
+    // Arrange
+    let store = new TranslationStore()
+    let listener = vi.fn()
+    store.updateOverrides({ 'cart.title': 'Bag' })
+
+    // Act
+    let unsubscribe = store.subscribe(listener)
+    store.setOverrides({ 'cart.subtitle': 'Items' })
+
+    // Assert — setOverrides replaces (not merges) and notifies once.
+    expect(store.getSnapshot()).toEqual({ 'cart.subtitle': 'Items' })
+    expect(store.getServerSnapshot()).toEqual({ 'cart.subtitle': 'Items' })
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    // Act — after unsubscribe, no further notifications.
+    unsubscribe()
+    store.setOverrides({ 'cart.title': 'Cart' })
+
+    // Assert
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('should_merge_overrides_on_updateOverrides_keeping_untouched_siblings', () => {
+    // Arrange
+    let store = new TranslationStore()
+    store.setOverrides({ 'cart.title': 'Cart', 'cart.subtitle': 'Items' })
+
+    // Act — update one key; the sibling must survive.
+    store.updateOverrides({ 'cart.title': 'Shopping Cart' })
+
+    // Assert
+    expect(store.getSnapshot()).toEqual({
+      'cart.title': 'Shopping Cart',
+      'cart.subtitle': 'Items',
+    })
+  })
+})
+
+describe('translation helpers', () => {
+  it('should_read_nested_dot_paths_and_fall_back_when_missing_or_non_string', () => {
+    expect(getNestedKey({ cart: { title: 'Cart' } }, 'cart.title')).toBe('Cart')
+    expect(getNestedKey({}, 'cart.title', 'fallback')).toBe('fallback')
+    // A non-string leaf resolves to the fallback, never the object itself.
+    expect(getNestedKey({ cart: { title: {} } }, 'cart.title')).toBeUndefined()
+  })
+
+  it('should_interpolate_double_brace_variables_and_leave_unknowns_intact', () => {
+    expect(interpolate('Hello {{name}}!', { name: 'World' })).toBe(
+      'Hello World!'
+    )
+    expect(interpolate('-{{percentage}}% Off', { percentage: 15 })).toBe(
+      '-15% Off'
+    )
+    expect(interpolate('Hi {{missing}}', { name: 'x' })).toBe('Hi {{missing}}')
+  })
+})
+
+describe('createTranslate priority chain', () => {
+  it('should_resolve_external_then_design_then_merchant_then_static_then_key', () => {
+    // Arrange — externalT only knows one key and echoes the rest, so the
+    // internal chain (design > merchant > static > key) continues for those.
+    let externalT = vi.fn((key: string) =>
+      key === 'nav.home' ? 'Accueil' : key
+    )
+    let t = createTranslate({
+      staticContent: {
+        cart: { title: 'Cart', subtitle: 'Your items', footer: 'Checkout' },
+        badge: { sale: '-{{percentage}}% Off' },
+      },
+      merchantOverrides: {
+        cart: { title: 'Shopping Cart', subtitle: 'Locale items' },
+      },
+      designOverrides: { 'cart.title': 'Bag' },
+      externalT,
+    })
+
+    // Assert
+    expect(t('nav.home')).toBe('Accueil') // external t wins
+    expect(t('cart.title')).toBe('Bag') // design > merchant > static
+    expect(t('cart.subtitle')).toBe('Locale items') // merchant > static
+    expect(t('cart.footer')).toBe('Checkout') // static content
+    expect(t('badge.sale', { percentage: 15 })).toBe('-15% Off') // interpolate
+    expect(t('missing.key')).toBe('missing.key') // key fallback
+  })
+
+  it('should_only_apply_own_design_override_keys_so_prototype_is_not_leaked', () => {
+    // Arrange — an inherited Object.prototype member must not resolve through
+    // the design-override lookup (own-property check) or the static lookup.
+    let t = createTranslate({
+      staticContent: { greeting: 'Hi' },
+      designOverrides: {},
+    })
+
+    // Assert — `toString` is inherited, not an own key; falls back to the key.
+    expect(t('toString')).toBe('toString')
+  })
+})
+
+describe('TranslationProvider / useTranslation', () => {
+  it('should_resolve_translations_inside_the_provider_on_the_server', () => {
+    // Arrange
+    function Probe() {
+      let { t } = useTranslation()
+      return <span>{t('cart.title')}</span>
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <TranslationProvider staticContent={{ cart: { title: 'Cart' } }}>
+        <Probe />
+      </TranslationProvider>
+    )
+
+    // Assert
+    expect(html).toContain('Cart')
+  })
+
+  it('should_layer_live_store_design_overrides_over_static_content', () => {
+    // Arrange — an override already present in the store is picked up via
+    // getServerSnapshot during SSR (no window in the node test env).
+    let store = new TranslationStore()
+    store.setOverrides({ 'cart.title': 'Bag' })
+    function Probe() {
+      let { t } = useTranslation()
+      return <span>{t('cart.title')}</span>
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <TranslationProvider
+        staticContent={{ cart: { title: 'Cart' } }}
+        translationStore={store}
+      >
+        <Probe />
+      </TranslationProvider>
+    )
+
+    // Assert — design override beats static content.
+    expect(html).toContain('Bag')
+    expect(html).not.toContain('Cart')
+  })
+
+  it('should_expose_the_store_under_both_translationStore_and_deprecated_themeTextStore', () => {
+    // Arrange
+    let store = new TranslationStore()
+    let seen: unknown[] = []
+    function Probe() {
+      let value = useTranslation()
+      seen.push(value.translationStore, value.themeTextStore)
+      return null
+    }
+
+    // Act
+    renderToStaticMarkup(
+      <TranslationProvider staticContent={{}} translationStore={store}>
+        <Probe />
+      </TranslationProvider>
+    )
+
+    // Assert — one instance, exposed under both names.
+    expect(seen[0]).toBe(store)
+    expect(seen[1]).toBe(store)
+  })
+
+  it('should_throw_a_clear_error_when_useTranslation_is_used_outside_a_provider', () => {
+    // Arrange
+    function Probe() {
+      useTranslation()
+      return null
+    }
+
+    // Act + Assert
+    expect(() => renderToStaticMarkup(<Probe />)).toThrow(
+      OUTSIDE_TRANSLATION_PROVIDER_ERROR
+    )
+  })
+})
+
+describe('WeaverseNextRootProvider translation wiring', () => {
+  it('should_expose_useTranslation_to_root_children_using_staticContent', () => {
+    // Arrange — a global child (Header/Footer) under the root provider, with no
+    // route-level WeaverseNextProvider.
+    function Probe() {
+      let { t } = useTranslation()
+      return <span>{t('cart.title')}</span>
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextRootProvider staticContent={{ cart: { title: 'Cart' } }}>
+        <Probe />
+      </WeaverseNextRootProvider>
+    )
+
+    // Assert
+    expect(html).toContain('Cart')
+  })
+
+  it('should_derive_root_staticContent_from_themeSchema_i18n_when_no_prop', () => {
+    // Arrange
+    function Probe() {
+      let { t } = useTranslation()
+      return <span>{t('greeting')}</span>
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextRootProvider
+        themeSchema={{ i18n: { staticContent: { greeting: 'Hello' } } }}
+      >
+        <Probe />
+      </WeaverseNextRootProvider>
+    )
+
+    // Assert
+    expect(html).toContain('Hello')
+  })
+
+  it('should_share_one_translation_store_between_root_and_a_nested_route_provider', () => {
+    // Arrange — capture the adopted store both directly under root and under a
+    // nested route provider; adoption means the two are the same instance.
+    let client = makeClient()
+    let stores: unknown[] = []
+    function Capture() {
+      stores.push(useTranslation().translationStore)
+      return null
+    }
+
+    // Act
+    renderToStaticMarkup(
+      <WeaverseNextRootProvider staticContent={{ cart: { title: 'Cart' } }}>
+        <Capture />
+        <WeaverseNextProvider client={client}>
+          <Capture />
+        </WeaverseNextProvider>
+      </WeaverseNextRootProvider>
+    )
+
+    // Assert
+    expect(stores).toHaveLength(2)
+    expect(stores[0]).toBeInstanceOf(TranslationStore)
+    expect(stores[0]).toBe(stores[1])
+  })
+
+  it('should_let_a_route_child_read_root_staticContent_when_route_supplies_none', () => {
+    // Arrange — route provider passes no staticContent and its client has no
+    // themeSchema; a route child must still resolve via the adopted root value.
+    let client = makeClient()
+    function Probe() {
+      let { t } = useTranslation()
+      return <span>{t('cart.title')}</span>
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextRootProvider staticContent={{ cart: { title: 'Cart' } }}>
+        <WeaverseNextProvider client={client}>
+          <Probe />
+        </WeaverseNextProvider>
+      </WeaverseNextRootProvider>
+    )
+
+    // Assert
+    expect(html).toContain('Cart')
+  })
+
+  it('should_resolve_translations_for_page_tree_components_through_the_renderer', () => {
+    // Arrange — a registered section reads useTranslation() and must resolve
+    // against the root staticContent adopted by the route provider + renderer.
+    let ThemeText = () => {
+      let { t } = useTranslation()
+      return <div>{t('cart.title')}</div>
+    }
+    let client = createWeaverseNextClient({
+      projectId: 'proj-test',
+      components: [
+        {
+          default: ThemeText,
+          schema: createSchema({ type: 'theme-text', title: 'Theme text' }),
+        },
+      ],
+    })
+    client.data = {
+      page: {
+        id: 'page-tr-render',
+        rootId: 'tr-render-root',
+        items: [{ id: 'tr-render-root', type: 'theme-text' }],
+      },
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextRootProvider staticContent={{ cart: { title: 'Cart' } }}>
+        <WeaverseNextProvider client={client}>
+          <WeaverseNextRenderer />
+        </WeaverseNextProvider>
+      </WeaverseNextRootProvider>
+    )
+
+    // Assert
+    expect(html).toContain('Cart')
+  })
+})
+
+describe('runtime translation bridge', () => {
+  it('should_default_internal_translation_store_and_alias_when_none_provided', () => {
+    // Arrange
+    let client = makeClient()
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-default-page',
+        rootId: 'tr-default-item',
+        items: [{ id: 'tr-default-item', type: 'hero', data: {} }],
+      },
+    }
+
+    // Act
+    let runtime = createWeaverseNextRuntime({ client, data })
+
+    // Assert — a store exists and both names point at the same instance, so
+    // Builder's updateStaticText() RPC (which reads themeTextStore) works.
+    expect(runtime.internal.translationStore).toBeInstanceOf(TranslationStore)
+    expect(runtime.internal.themeTextStore).toBe(
+      runtime.internal.translationStore
+    )
+  })
+
+  it('should_attach_provided_translation_store_and_merchant_overrides_to_internal', () => {
+    // Arrange
+    let client = makeClient()
+    let translationStore = new TranslationStore()
+    let merchantOverrides = { cart: { title: 'Cart' } }
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-attach-page',
+        rootId: 'tr-attach-item',
+        items: [{ id: 'tr-attach-item', type: 'hero', data: {} }],
+      },
+    }
+
+    // Act
+    let runtime = createWeaverseNextRuntime({
+      client,
+      data,
+      merchantOverrides,
+      translationStore,
+    })
+
+    // Assert
+    expect(runtime.internal.translationStore).toBe(translationStore)
+    expect(runtime.internal.themeTextStore).toBe(translationStore)
+    expect(runtime.internal.merchantOverrides).toBe(merchantOverrides)
+  })
+
+  it('should_refresh_internal_translation_wiring_when_reusing_a_runtime', () => {
+    // Arrange — same page ID + URL, so the runtime is reused across loader
+    // passes; the adopted store/overrides must be refreshed onto internal.
+    let previousWindow = globalThis.window
+    let fakeWindow = {} as Window &
+      typeof globalThis & { __weaverses?: unknown }
+    vi.stubGlobal('window', fakeWindow)
+    let client = makeClient({
+      requestContext: { isDesignMode: false, pathname: '/' },
+    })
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-reuse-page',
+        rootId: 'tr-reuse-item',
+        items: [{ id: 'tr-reuse-item', type: 'hero', data: {} }],
+      },
+    }
+    let first = createWeaverseNextRuntime({ client, data })
+    let nextStore = new TranslationStore()
+    let nextOverrides = { cart: { title: 'Updated' } }
+
+    // Act
+    let reused = createWeaverseNextRuntime({
+      client,
+      data,
+      merchantOverrides: nextOverrides,
+      translationStore: nextStore,
+    })
+
+    // Assert — same runtime, translation wiring refreshed from the latest config.
+    expect(reused).toBe(first)
+    expect(reused.internal.translationStore).toBe(nextStore)
+    expect(reused.internal.themeTextStore).toBe(nextStore)
+    expect(reused.internal.merchantOverrides).toBe(nextOverrides)
+
+    // Act — a later loader pass with no overrides must clear the previous
+    // locale's overrides instead of leaking them into the next render.
+    let cleared = createWeaverseNextRuntime({
+      client,
+      data,
+      translationStore: nextStore,
+    })
+
+    // Assert
+    expect(cleared).toBe(first)
+    expect(cleared.internal.merchantOverrides).toBeUndefined()
     vi.stubGlobal('window', previousWindow)
   })
 })

--- a/packages/next/__tests__/next-server.test.tsx
+++ b/packages/next/__tests__/next-server.test.tsx
@@ -502,6 +502,30 @@ describe('createWeaverseNextServerClient loadThemeSettings', () => {
     expect(result.staticContent).toEqual({ greeting: 'Hello' })
   })
 
+  it('should_preserve_merchant_overrides_returned_by_the_api', async () => {
+    // Arrange — the storefront API returns locale-specific overrides alongside
+    // the theme; the server client must pass them through untouched so the root
+    // provider can feed them into the translation chain.
+    let fetchMock = makeFetch({
+      theme: { topbarText: 'Remote topbar' },
+      merchantOverrides: { cart: { title: 'Panier' } },
+    })
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      themeSchema,
+      fetch: fetchMock,
+      requestContext: { url: 'https://shop.example/' },
+    })
+
+    // Act
+    let result = await client.loadThemeSettings()
+
+    // Assert — merchant overrides preserved; static content still injected.
+    expect(result.merchantOverrides).toEqual({ cart: { title: 'Panier' } })
+    expect(result.staticContent).toEqual({ greeting: 'Hello' })
+  })
+
   it('should_return_fallback_with_defaults_when_api_fails', async () => {
     let error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     let fetchMock = vi

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -79,6 +79,21 @@ export {
   type CreateWeaverseNextThemeSettingsStoreOptions,
   createWeaverseNextThemeSettingsStore,
 } from './theme-settings-store'
+export {
+  createTranslate,
+  getNestedKey,
+  interpolate,
+  ThemeTextProvider,
+  type ThemeTextProviderProps,
+  type ThemeTextValue,
+  type TranslateFunction,
+  TranslationProvider,
+  type TranslationProviderProps,
+  type TranslationValue,
+  useThemeText,
+  useTranslation,
+} from './translation-context'
+export { ThemeTextStore, TranslationStore } from './translation-store'
 export type {
   WeaverseArticle,
   WeaverseBlog,

--- a/packages/next/src/provider.tsx
+++ b/packages/next/src/provider.tsx
@@ -10,6 +10,11 @@ import {
 } from 'react'
 import { WeaverseNextRootContext } from './root-provider'
 import { createWeaverseNextThemeSettingsStore } from './theme-settings-store'
+import {
+  type TranslateFunction,
+  TranslationProvider,
+} from './translation-context'
+import { TranslationStore } from './translation-store'
 import type {
   WeaverseNextClient,
   WeaverseNextCommerceContext,
@@ -17,6 +22,16 @@ import type {
 } from './types'
 
 const EMPTY_THEME_SETTINGS: Record<string, unknown> = {}
+const EMPTY_STATIC_CONTENT: Record<string, unknown> = {}
+
+/** Read `themeSchema.i18n.staticContent` for the fallback (no-root) provider. */
+export function getSchemaStaticContent(
+  schema: unknown
+): Record<string, unknown> {
+  let i18n = (schema as { i18n?: { staticContent?: Record<string, unknown> } })
+    ?.i18n
+  return i18n?.staticContent ?? EMPTY_STATIC_CONTENT
+}
 
 /**
  * Value carried by {@link WeaverseNextContext}. Holds the explicit data
@@ -26,10 +41,14 @@ const EMPTY_THEME_SETTINGS: Record<string, unknown> = {}
 export interface WeaverseNextContextValue {
   client?: WeaverseNextClient
   commerce?: WeaverseNextCommerceContext
+  /** Active-locale static-text overrides, threaded into the runtime. */
+  merchantOverrides?: Record<string, unknown>
   pageData?: unknown
   rootData?: unknown
   themeSettings: Record<string, unknown>
   themeSettingsStore: WeaverseNextThemeSettingsStore
+  /** Live design-mode static-text override store, threaded into the runtime. */
+  translationStore: TranslationStore
 }
 
 /**
@@ -44,10 +63,23 @@ export interface WeaverseNextProviderProps {
   client?: WeaverseNextClient
   /** App-provided commerce context (storefront/cart/customer). */
   commerce?: WeaverseNextCommerceContext
+  /**
+   * Active-locale static-text overrides (nested, from `loadThemeSettings()`).
+   * Adopts the root provider's `merchantOverrides` when omitted.
+   */
+  merchantOverrides?: Record<string, unknown>
   /** Explicit page/route commerce data (replaces section-level `useLoaderData`). */
   pageData?: unknown
   /** Explicit root/global data (replaces `useRouteLoaderData('root')`). */
   rootData?: unknown
+  /**
+   * Theme default locale JSON (`loadThemeSettings().staticContent`). Adopts the
+   * root provider's `staticContent` when omitted, then falls back to
+   * `client.themeSchema.i18n.staticContent`.
+   */
+  staticContent?: Record<string, unknown>
+  /** Optional external translation function (host i18n); highest priority in `t()`. */
+  t?: TranslateFunction
   /** Theme settings override; falls back to `client.themeSettings`. */
   themeSettings?: Record<string, unknown>
 }
@@ -76,6 +108,29 @@ export function WeaverseNextProvider(props: WeaverseNextProviderProps) {
 
   let themeSettingsValue =
     themeSettings ?? client?.themeSettings ?? EMPTY_THEME_SETTINGS
+
+  // Fallback translation store when no `WeaverseNextRootProvider` is mounted.
+  // Otherwise the ambient root store is adopted, so exactly one live static-text
+  // store backs Builder's `updateStaticText()` RPC per page load — mirroring the
+  // theme-settings store adoption below. `useRef`, not `useMemo`: React may
+  // evict memoized values, but this store must survive every re-render so
+  // design-mode overrides already applied by Builder are never dropped.
+  let ownTranslationStoreRef = useRef<TranslationStore | null>(null)
+  if (!(rootContext || ownTranslationStoreRef.current)) {
+    ownTranslationStoreRef.current = new TranslationStore()
+  }
+  let translationStore =
+    rootContext?.translationStore ??
+    (ownTranslationStoreRef.current as TranslationStore)
+
+  // Static content / merchant overrides feeding `useTranslation()`. Precedence:
+  // explicit prop → ambient root value → (static content only) schema default.
+  let staticContent =
+    props.staticContent ??
+    rootContext?.staticContent ??
+    getSchemaStaticContent(client?.themeSchema)
+  let merchantOverrides =
+    props.merchantOverrides ?? rootContext?.merchantOverrides
 
   // Fallback store for apps that don't mount `WeaverseNextRootProvider`. Not
   // created at all when a root store is present, so exactly one
@@ -130,15 +185,32 @@ export function WeaverseNextProvider(props: WeaverseNextProviderProps) {
       rootData,
       pageData,
       commerce: commerce ?? client?.commerce,
+      merchantOverrides,
       themeSettings: themeSettingsStore.getSnapshot(),
       themeSettingsStore,
+      translationStore,
     }),
-    [client, rootData, pageData, commerce, themeSettingsStore]
+    [
+      client,
+      rootData,
+      pageData,
+      commerce,
+      merchantOverrides,
+      themeSettingsStore,
+      translationStore,
+    ]
   )
 
   return (
     <WeaverseNextContext.Provider value={value}>
-      {children}
+      <TranslationProvider
+        merchantOverrides={merchantOverrides}
+        staticContent={staticContent}
+        t={props.t}
+        translationStore={translationStore}
+      >
+        {children}
+      </TranslationProvider>
     </WeaverseNextContext.Provider>
   )
 }

--- a/packages/next/src/renderer.tsx
+++ b/packages/next/src/renderer.tsx
@@ -65,9 +65,19 @@ export const WeaverseNextRenderer = memo(function WeaverseNextRendererComponent(
       client,
       data: { ...(data as WeaverseNextLoaderData), page },
       dataContext,
+      merchantOverrides: context?.merchantOverrides,
       themeSettingsStore: context?.themeSettingsStore,
+      translationStore: context?.translationStore,
     })
-  }, [client, page, data, dataContext, context?.themeSettingsStore])
+  }, [
+    client,
+    page,
+    data,
+    dataContext,
+    context?.merchantOverrides,
+    context?.themeSettingsStore,
+    context?.translationStore,
+  ])
 
   if (!weaverse) {
     return null

--- a/packages/next/src/root-provider.tsx
+++ b/packages/next/src/root-provider.tsx
@@ -7,12 +7,27 @@ import {
   useMemo,
   useRef,
 } from 'react'
-import { WeaverseNextContext, type WeaverseNextContextValue } from './provider'
+import {
+  getSchemaStaticContent,
+  WeaverseNextContext,
+  type WeaverseNextContextValue,
+} from './provider'
 import { createWeaverseNextThemeSettingsStore } from './theme-settings-store'
+import {
+  type TranslateFunction,
+  TranslationProvider,
+} from './translation-context'
+import { TranslationStore } from './translation-store'
 import type { WeaverseNextThemeSettingsStore } from './types'
 
 export interface WeaverseNextRootContextValue {
+  /** Active-locale static-text overrides shared with route-level providers. */
+  merchantOverrides?: Record<string, unknown>
+  /** Theme default locale JSON shared with route-level providers. */
+  staticContent: Record<string, unknown>
   themeSettingsStore: WeaverseNextThemeSettingsStore
+  /** Single live design-mode static-text override store for the whole session. */
+  translationStore: TranslationStore
 }
 
 /**
@@ -26,7 +41,16 @@ export interface WeaverseNextRootProviderProps {
   children: ReactNode
   /** Root-loaded theme settings (published-mode fetch, no design-mode context). */
   initialThemeSettings?: Record<string, unknown>
+  /** Active-locale static-text overrides from `loadThemeSettings().merchantOverrides`. */
+  merchantOverrides?: Record<string, unknown>
   publicEnv?: Record<string, string | undefined>
+  /**
+   * Theme default locale JSON (`loadThemeSettings().staticContent`). Falls back
+   * to `themeSchema.i18n.staticContent` when omitted.
+   */
+  staticContent?: Record<string, unknown>
+  /** Optional external translation function (host i18n); highest priority in `t()`. */
+  t?: TranslateFunction
   themeSchema?: unknown
 }
 
@@ -50,7 +74,15 @@ export interface WeaverseNextRootProviderProps {
  * ```
  */
 export function WeaverseNextRootProvider(props: WeaverseNextRootProviderProps) {
-  let { children, initialThemeSettings, themeSchema, publicEnv } = props
+  let {
+    children,
+    initialThemeSettings,
+    merchantOverrides,
+    staticContent,
+    t,
+    themeSchema,
+    publicEnv,
+  } = props
 
   // `useRef`, not `useMemo`: a parent re-render must never replace this store —
   // it is the single instance Studio's `updateThemeSettings()` mutates in place.
@@ -63,6 +95,16 @@ export function WeaverseNextRootProvider(props: WeaverseNextRootProviderProps) {
     })
   }
   let themeSettingsStore = storeRef.current
+
+  // Same `useRef` rationale as the theme store: one live static-text store for
+  // the whole session, which Builder's `updateStaticText()` RPC mutates in place
+  // via `runtime.internal.translationStore`. A parent re-render must never swap
+  // it, or design-mode overrides would be lost.
+  let translationStoreRef = useRef<TranslationStore | null>(null)
+  if (!translationStoreRef.current) {
+    translationStoreRef.current = new TranslationStore()
+  }
+  let translationStore = translationStoreRef.current
 
   // If `initialThemeSettings` changes after mount (e.g. root revalidation),
   // update the existing store in place instead of replacing it. This is an
@@ -79,25 +121,51 @@ export function WeaverseNextRootProvider(props: WeaverseNextRootProviderProps) {
     }
   }, [initialThemeSettings, themeSettingsStore])
 
-  // `themeSettingsStore` is `useRef`-stable, so memoizing on it (rather than
-  // recreating these plain objects every render) keeps `useThemeSettings()`
-  // consumers (Header, Footer, ...) from re-rendering on every root re-render.
+  // Prefer an explicit `staticContent` prop (from `loadThemeSettings()`); fall
+  // back to `themeSchema.i18n.staticContent`. Both resolve to referentially
+  // stable objects, so memoizing the context values below stays effective.
+  let resolvedStaticContent =
+    staticContent ?? getSchemaStaticContent(themeSchema)
+
+  // `themeSettingsStore` / `translationStore` are `useRef`-stable, so memoizing
+  // on them (rather than recreating these plain objects every render) keeps
+  // `useThemeSettings()` / `useTranslation()` consumers (Header, Footer, ...)
+  // from re-rendering on every root re-render.
   let rootContextValue = useMemo<WeaverseNextRootContextValue>(
-    () => ({ themeSettingsStore }),
-    [themeSettingsStore]
+    () => ({
+      merchantOverrides,
+      staticContent: resolvedStaticContent,
+      themeSettingsStore,
+      translationStore,
+    }),
+    [
+      merchantOverrides,
+      resolvedStaticContent,
+      themeSettingsStore,
+      translationStore,
+    ]
   )
   let contextValue = useMemo<WeaverseNextContextValue>(
     () => ({
+      merchantOverrides,
       themeSettings: themeSettingsStore.getSnapshot(),
       themeSettingsStore,
+      translationStore,
     }),
-    [themeSettingsStore]
+    [merchantOverrides, themeSettingsStore, translationStore]
   )
 
   return (
     <WeaverseNextRootContext.Provider value={rootContextValue}>
       <WeaverseNextContext.Provider value={contextValue}>
-        {children}
+        <TranslationProvider
+          merchantOverrides={merchantOverrides}
+          staticContent={resolvedStaticContent}
+          t={t}
+          translationStore={translationStore}
+        >
+          {children}
+        </TranslationProvider>
       </WeaverseNextContext.Provider>
     </WeaverseNextRootContext.Provider>
   )

--- a/packages/next/src/runtime.ts
+++ b/packages/next/src/runtime.ts
@@ -2,6 +2,7 @@ import { Weaverse } from '@weaverse/react'
 import { ensureNextItemConstructor } from './item'
 import { buildWeaverseNextRequestInfo } from './request-info'
 import { createWeaverseNextThemeSettingsStore } from './theme-settings-store'
+import { TranslationStore } from './translation-store'
 import type {
   WeaverseNextClient,
   WeaverseNextLoaderData,
@@ -134,7 +135,14 @@ export class WeaverseNextRuntime extends Weaverse {
     this.isRevisionPreview = requestContext?.isRevisionPreview ?? false
     this.sectionType = requestContext?.sectionType
 
+    // One store instance backs both the canonical `translationStore` and the
+    // deprecated `themeTextStore` alias, so Builder's `updateStaticText()` RPC
+    // (which reads `internal.themeTextStore`) mutates the same store the
+    // `TranslationProvider` subscribes to.
+    let translationStore = config.translationStore ?? new TranslationStore()
+
     this.internal = {
+      merchantOverrides: config.merchantOverrides,
       navigate: config.navigate,
       pageAssignment: data.pageAssignment,
       project: data.project,
@@ -145,6 +153,8 @@ export class WeaverseNextRuntime extends Weaverse {
           schema: client?.themeSchema,
           settings: client?.themeSettings,
         }),
+      translationStore,
+      themeTextStore: translationStore,
     }
   }
 
@@ -217,6 +227,15 @@ export function createWeaverseNextRuntime(
     if (config.themeSettingsStore) {
       existing.internal.themeSettingsStore = config.themeSettingsStore
     }
+    if (config.translationStore) {
+      existing.internal.translationStore = config.translationStore
+      // Keep the deprecated alias pointing at the same adopted instance.
+      existing.internal.themeTextStore = config.translationStore
+    }
+    // Always assign, including `undefined`, so locale/navigation changes can
+    // clear previously attached merchant overrides instead of leaking stale
+    // static-text values into the next render.
+    existing.internal.merchantOverrides = config.merchantOverrides
     registerRuntime(existing)
     return existing
   }

--- a/packages/next/src/translation-context.tsx
+++ b/packages/next/src/translation-context.tsx
@@ -1,0 +1,271 @@
+'use client'
+
+import { useSafeExternalStore } from '@weaverse/react'
+import { createContext, type ReactNode, useContext, useMemo } from 'react'
+import type { TranslationStore } from './translation-store'
+
+/**
+ * Traverse a nested object by dot-path.
+ *
+ * @example
+ * getNestedKey({ cart: { title: 'Cart' } }, 'cart.title') // => 'Cart'
+ * getNestedKey({}, 'cart.title', 'fallback')              // => 'fallback'
+ */
+export function getNestedKey(
+  obj: Record<string, unknown>,
+  path: string,
+  fallback?: string
+): string | undefined {
+  let keys = path.split('.')
+  let current: unknown = obj
+
+  for (let key of keys) {
+    if (current == null || typeof current !== 'object') {
+      return fallback
+    }
+    current = (current as Record<string, unknown>)[key]
+  }
+
+  if (typeof current === 'string') {
+    return current
+  }
+
+  return fallback
+}
+
+/**
+ * Replace `{{variable}}` patterns in a string with provided values.
+ *
+ * @example
+ * interpolate('Hello {{name}}!', { name: 'World' }) // => 'Hello World!'
+ * interpolate('-{{percentage}}% Off', { percentage: 15 }) // => '-15% Off'
+ */
+export function interpolate(
+  template: string,
+  variables?: Record<string, string | number>
+): string {
+  if (!variables) {
+    return template
+  }
+
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key: string) => {
+    let value = variables[key]
+    return value === undefined ? match : String(value)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Context & Provider
+// ---------------------------------------------------------------------------
+
+/**
+ * Signature for a translation function.
+ */
+export type TranslateFunction = (
+  key: string,
+  variables?: Record<string, string | number>
+) => string
+
+export interface TranslationValue {
+  /** Active-locale translated keys loaded from the storefront API. */
+  merchantOverrides: Record<string, unknown> | null
+  /**
+   * Translate a key with optional variable interpolation.
+   *
+   * Priority chain (highest wins):
+   * 1. External `t`        (passed into `WeaverseNextRootProvider` / `TranslationProvider`)
+   * 2. Design overrides   (live Builder edits from `TranslationStore`)
+   * 3. `merchantOverrides` (DB/API overrides for the current locale)
+   * 4. `staticContent`     (theme default JSON)
+   * 5. The key itself      (fallback)
+   *
+   * @example
+   * t('cart.title')                           // => "Cart"
+   * t('badge.sale', { percentage: 15 })       // => "-15% Off"
+   */
+  t: TranslateFunction
+  /**
+   * @deprecated Use {@link TranslationValue.translationStore} instead. Kept as a
+   * backward-compatible alias pointing at the same store instance.
+   */
+  themeTextStore: TranslationStore | null
+  /** Exposed so the runtime/Studio bridge can attach it to `internal`. */
+  translationStore: TranslationStore | null
+}
+
+const TranslationContext = createContext<TranslationValue | null>(null)
+TranslationContext.displayName = 'WeaverseNextTranslationContext'
+
+export interface TranslationProviderProps {
+  children: ReactNode
+  merchantOverrides?: Record<string, unknown>
+  staticContent: Record<string, unknown>
+  /**
+   * Optional external translation function.
+   * When provided it becomes the **highest-priority** source:
+   * if it returns a non-empty string that differs from the raw key,
+   * that value is used; otherwise the internal resolution chain continues.
+   */
+  t?: TranslateFunction
+  /**
+   * @deprecated Use {@link TranslationProviderProps.translationStore} instead.
+   * Still accepted for backward compatibility; ignored when `translationStore`
+   * is also provided.
+   */
+  themeTextStore?: TranslationStore | null
+  /** Optional store for live design-mode text overrides from the builder. */
+  translationStore?: TranslationStore | null
+}
+
+/**
+ * Build the `t()` translation function over a fixed set of sources.
+ *
+ * Resolution order, highest priority first:
+ * 1. `externalT`         – host i18n (e.g. Shopify), unless it echoes the key
+ * 2. `designOverrides`   – live design-mode edits, flat dot-path keys
+ * 3. `merchantOverrides` – locale overrides from the API, nested
+ * 4. `staticContent`     – the theme's default locale JSON
+ * 5. the key itself
+ *
+ * Design overrides are looked up per-key (own properties only) rather than
+ * merged into `merchantOverrides`: a flat key like `cart.title` must override
+ * exactly that leaf without wiping sibling keys (`cart.subtitle`), and a
+ * per-key own-property lookup never builds nested objects from
+ * merchant-controlled keys, so it cannot pollute `Object.prototype`.
+ */
+export function createTranslate(sources: {
+  staticContent: Record<string, unknown>
+  merchantOverrides?: Record<string, unknown>
+  designOverrides?: Record<string, string>
+  externalT?: TranslateFunction
+}): TranslateFunction {
+  let { staticContent, merchantOverrides, designOverrides, externalT } = sources
+  return (key, variables) => {
+    // Priority 1: external t (e.g. Shopify i18n, third-party library).
+    if (externalT) {
+      let external = externalT(key, variables)
+      // Accept the external value unless it echoed the key unchanged.
+      if (external && external !== key) {
+        return external
+      }
+    }
+
+    // Priority 2: live design-mode override (flat, keyed by exact dot-path,
+    // own properties only so inherited keys never resolve to functions).
+    let design =
+      designOverrides && Object.hasOwn(designOverrides, key)
+        ? designOverrides[key]
+        : undefined
+    // Priority 3: merchant overrides (nested). Priority 4: static content.
+    let override = merchantOverrides
+      ? getNestedKey(merchantOverrides, key)
+      : undefined
+    let staticValue = getNestedKey(staticContent, key)
+
+    // Priority 5: the key itself as the final fallback.
+    let raw = design ?? override ?? staticValue ?? key
+    return interpolate(raw, variables)
+  }
+}
+
+// No-op fallback for useSafeExternalStore when store is null (production).
+// Module-level constants — stable references, zero allocation per render.
+const EMPTY: Record<string, string> = {}
+const NOOP_SUBSCRIBE = () => () => {
+  // No-op unsubscribe for production/static renders without a translation store.
+}
+const NOOP_SNAPSHOT = () => EMPTY
+
+/**
+ * Provider that wraps the app to expose the `t()` function.
+ *
+ * - `staticContent`      – the theme's default locale JSON (from themeSchema.i18n)
+ * - `merchantOverrides`  – locale-specific overrides fetched from the API
+ * - `translationStore`   – optional store for live design-mode text overrides
+ *   (the deprecated `themeTextStore` prop is accepted as a fallback)
+ */
+export function TranslationProvider({
+  staticContent,
+  merchantOverrides,
+  t: externalT,
+  translationStore,
+  themeTextStore,
+  children,
+}: TranslationProviderProps) {
+  // Canonical store, falling back to the deprecated `themeTextStore` prop.
+  let store = translationStore ?? themeTextStore ?? null
+
+  // Subscribe to design-mode overrides. No-op when store is null (production).
+  let designOverrides = useSafeExternalStore(
+    store?.subscribe ?? NOOP_SUBSCRIBE,
+    store?.getSnapshot ?? NOOP_SNAPSHOT,
+    store?.getServerSnapshot ?? NOOP_SNAPSHOT
+  )
+
+  let value = useMemo<TranslationValue>(
+    () => ({
+      t: createTranslate({
+        staticContent,
+        merchantOverrides,
+        designOverrides,
+        externalT,
+      }),
+      translationStore: store,
+      // Deprecated alias — same instance, kept for backward compatibility.
+      themeTextStore: store,
+      merchantOverrides: merchantOverrides ?? null,
+    }),
+    [staticContent, merchantOverrides, designOverrides, externalT, store]
+  )
+
+  return (
+    <TranslationContext.Provider value={value}>
+      {children}
+    </TranslationContext.Provider>
+  )
+}
+
+/**
+ * Hook to access the translation `t()` function.
+ *
+ * Must be used inside a component wrapped by `WeaverseNextRootProvider` or
+ * `TranslationProvider`.
+ *
+ * @example
+ * ```tsx
+ * function CartTitle() {
+ *   let { t } = useTranslation()
+ *   return <h2>{t('cart.title')}</h2>
+ * }
+ * ```
+ */
+export function useTranslation(): TranslationValue {
+  let ctx = useContext(TranslationContext)
+  if (!ctx) {
+    throw new Error(
+      'useTranslation must be used within <TranslationProvider>. Wrap your app with <WeaverseNextRootProvider>.'
+    )
+  }
+  return ctx
+}
+
+// ---------------------------------------------------------------------------
+// Deprecated aliases (backward compatibility — kept exported indefinitely)
+// ---------------------------------------------------------------------------
+
+/**
+ * @deprecated Use {@link TranslationProvider} instead.
+ */
+export const ThemeTextProvider = TranslationProvider
+/**
+ * @deprecated Use {@link useTranslation} instead.
+ */
+export const useThemeText = useTranslation
+/**
+ * @deprecated Use {@link TranslationValue} instead.
+ */
+export type ThemeTextValue = TranslationValue
+/**
+ * @deprecated Use {@link TranslationProviderProps} instead.
+ */
+export type ThemeTextProviderProps = TranslationProviderProps

--- a/packages/next/src/translation-store.ts
+++ b/packages/next/src/translation-store.ts
@@ -1,0 +1,60 @@
+/**
+ * Minimal mutable store for design-mode static text overrides.
+ *
+ * `useSyncExternalStore`-compatible. Passed into {@link TranslationProvider}
+ * (from `./translation-context`) which subscribes internally and layers
+ * overrides on top of `merchantOverrides`/`staticContent`. The Studio bridge
+ * calls `updateOverrides()` via `runtime.internal.translationStore` (also
+ * exposed as the deprecated `runtime.internal.themeTextStore` alias) so live
+ * static-text edits reach the runtime — identical surface to Hydrogen's store,
+ * so Builder's existing static-text RPC works with `@weaverse/next` unchanged.
+ *
+ * Shape: flat `Record<string, string>` — dot-notation keys map to values
+ * (e.g. "cart.title" → "Shopping Cart").
+ */
+export class TranslationStore {
+  overrides: Record<string, string> = {}
+  private readonly listeners: Set<() => void> = new Set()
+
+  setOverrides = (overrides: Record<string, string>) => {
+    this.overrides = { ...overrides }
+    this.emit()
+  }
+
+  updateOverrides = (newOverrides: Record<string, string>) => {
+    this.overrides = { ...this.overrides, ...newOverrides }
+    this.emit()
+  }
+
+  getSnapshot = () => this.overrides
+
+  getServerSnapshot = () => this.overrides
+
+  subscribe = (callback: () => void) => {
+    this.listeners.add(callback)
+    return () => {
+      this.listeners.delete(callback)
+    }
+  }
+
+  private readonly emit = () => {
+    for (const listener of Array.from(this.listeners)) {
+      try {
+        listener()
+      } catch (error) {
+        console.error('TranslationStore: Listener error', error)
+      }
+    }
+  }
+}
+
+/**
+ * @deprecated Use {@link TranslationStore} instead. Kept as a backward-compatible
+ * alias and will remain exported for existing integrations.
+ */
+export const ThemeTextStore = TranslationStore
+/**
+ * @deprecated Use {@link TranslationStore} instead. Kept as a backward-compatible
+ * alias and will remain exported for existing integrations.
+ */
+export type ThemeTextStore = TranslationStore

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -4,6 +4,7 @@ import type {
 } from '@weaverse/react'
 import type { PageSEOData, PageType, SchemaType } from '@weaverse/schema'
 import type { ComponentType, ForwardRefExoticComponent, ReactNode } from 'react'
+import type { TranslationStore } from './translation-store'
 
 export interface WeaverseNextRequestInfo {
   i18n?: WeaverseNextI18n
@@ -45,6 +46,8 @@ export interface WeaverseNextPageAssignment {
 }
 
 export interface WeaverseNextRuntimeInternal {
+  /** Active-locale static-text overrides fetched from the API (nested). */
+  merchantOverrides?: Record<string, unknown>
   navigate?: (
     to: string,
     options?: { preventScrollReset?: boolean } | Record<string, unknown>
@@ -59,15 +62,31 @@ export interface WeaverseNextRuntimeInternal {
    */
   revalidateItem?: (draftItem: WeaverseNextComponentData) => Promise<void>
   themeSettingsStore?: WeaverseNextThemeSettingsStore
+  /**
+   * @deprecated Use {@link WeaverseNextRuntimeInternal.translationStore}
+   * instead. Same instance, kept so Builder's existing `updateStaticText()`
+   * RPC (which reads `internal.themeTextStore`) works with Next unchanged.
+   */
+  themeTextStore?: TranslationStore
+  /**
+   * Live design-mode static-text override store. Builder's `updateStaticText()`
+   * RPC mutates it via `updateOverrides()`; the `TranslationProvider` observing
+   * the same instance re-renders `useTranslation()` consumers.
+   */
+  translationStore?: TranslationStore
 }
 
 export interface WeaverseNextRuntimeConfig {
   client?: WeaverseNextClient
   data: WeaverseNextLoaderData
   dataContext?: Record<string, unknown>
+  /** Active-locale static-text overrides threaded onto `internal`. */
+  merchantOverrides?: Record<string, unknown>
   navigate?: WeaverseNextRuntimeInternal['navigate']
   revalidate?: WeaverseNextRuntimeInternal['revalidate']
   themeSettingsStore?: WeaverseNextThemeSettingsStore
+  /** Root/route-owned translation store to attach to `internal`. */
+  translationStore?: TranslationStore
 }
 
 /**


### PR DESCRIPTION
## Summary
- add Next static-text translation store/provider/hooks (`useTranslation`, `TranslationProvider`) with deprecated `ThemeText` aliases
- wire root/provider/renderer/runtime so Builder static-text RPC can update `internal.translationStore` / `internal.themeTextStore`
- preserve `merchantOverrides`, schema `staticContent`, and clear stale overrides on reused runtimes

## Verification
- `pnpm --filter @weaverse/next test -- __tests__/next-adapter.test.tsx __tests__/next-server.test.tsx` — 5 files, 107 tests passed
- `pnpm --filter @weaverse/next typecheck` — passed
- `pnpm --filter @weaverse/next build` — passed
- `pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error` — passed
- `git diff --check` — passed
- autoreview-copilot — clean
