### PR TITLE
Add Next item translation sidecar

### DIFF
--- a/.specs/2026-06-21--next-studio-bridge/claude-handoff-next-item-translation-sidecar.md
+++ b/.specs/2026-06-21--next-studio-bridge/claude-handoff-next-item-translation-sidecar.md
@@ -1,0 +1,127 @@
+# Claude handoff — Next item-level translation sidecar parity
+
+## Repo / branch
+
+- Repo: `/Users/hta218/Documents/work/workspace/weaverse`
+- Branch: `feat/next-item-translation-sidecar`
+- Base: `main` after PR #488 (`c2a52a2f` merged)
+- Tracker: https://github.com/Weaverse/builder/issues/2659
+
+## Context
+
+Continuing Next Productionization Epic 2663.
+
+Landed already:
+
+- PR #488: static-text translation foundation for `@weaverse/next`.
+  - `TranslationStore`, `TranslationProvider`, `useTranslation`, deprecated `ThemeText*` aliases.
+  - Root/provider/renderer/runtime static text wiring for Builder RPC via `internal.translationStore` / `internal.themeTextStore`.
+
+This new PR should implement the **item-level/page translation sidecar** parity with Hydrogen, without touching Builder.
+
+## Hydrogen reference
+
+Files already audited:
+
+- `packages/hydrogen/src/WeaverseHydrogenRoot.tsx`
+  - `WeaverseHydrogenItem.getSnapShot()` overlays `weaverse.translationMap[itemId][key].translatedValue` on top of `_store`.
+  - Snapshot is memoized by `_store` ref and per-item translation entry ref.
+  - `WeaverseHydrogen` has:
+    - `translationMap: TranslationMap = {}`
+    - `translationLocale = ''`
+    - `translationLanguageId = ''`
+    - `extractTranslationSidecar()` reads `translationMap`, `translationLocale`, `translationLanguageId` from page data.
+    - `setTranslationSidecar(map, locale, languageId)` sets values, refreshes all items.
+    - `updateTranslation(itemId, key, originalValue, translatedValue)` updates one entry, creates new per-item ref, triggers that item.
+    - `getTranslationChanges()` returns `{ languageId, entries: [{ itemId, key: 'data.<key>', originalValue, translatedValue }] }` when locale/languageId exist and entries non-empty.
+    - `setProjectData(data)` re-extracts sidecar before `initProject()`.
+- `packages/hydrogen/src/types.ts`
+  - `TranslationMapEntry`, `TranslationItemEntry`, `TranslationMap`, `TranslationEntry`, `TranslationChanges` shapes.
+
+Builder Studio expectations:
+
+- `builder/studio/rpc/methods.ts::updateItemData()`:
+  - translation mode is `!!weaverse.translationLocale && typeof weaverse.updateTranslation === 'function'`.
+  - translatable schema fields route to `weaverse.updateTranslation(id, key, instance._store[key] ?? '', value)`.
+  - non-translatable fields still update `_store`.
+- `builder/studio/utils/data.ts::generateItemInfo()` reads `item.getSnapShot()` so selected sidebar sees translated values.
+- `builder/studio/utils/data.ts::silentUpdate()` sends `translationDraft` with `weaverse.translationMap`, locale, languageId.
+- `builder/studio/rpc/methods.ts::getTranslationChanges()` collects first non-empty `weaverse.getTranslationChanges()` from `window.__weaverses`.
+
+Current Next state:
+
+- `packages/next/src/runtime.ts` has placeholder translation fields/methods:
+  - `translationMap: Record<string, unknown> = {}`
+  - `translationLocale = ''`
+  - `translationLanguageId = ''`
+  - `extractTranslationSidecar = () => undefined`
+  - `setTranslationSidecar(...)` only assigns fields, no refresh.
+  - `updateTranslation = () => undefined`
+  - `getTranslationChanges = () => undefined`
+- `packages/next/src/item.ts` flattens data/schema defaults but does not overlay translations.
+- `packages/next/src/types.ts` does not define Next-specific translation map/change types.
+- `packages/next/__tests__/next-adapter.test.tsx` is the main runtime/provider test file.
+
+## Goal
+
+Implement item-level translation sidecar parity in `@weaverse/next`, matching Hydrogen behavior.
+
+Required changes:
+
+1. Add Next translation sidecar types in `packages/next/src/types.ts` and export them from `packages/next/src/index.ts`:
+   - `WeaverseNextTranslationMapEntry`
+   - `WeaverseNextTranslationItemEntry`
+   - `WeaverseNextTranslationMap`
+   - `WeaverseNextTranslationEntry`
+   - `WeaverseNextTranslationChanges`
+   Keep shapes aligned with Hydrogen. Values can be strings for now, but consider object values if needed to match Builder image handling; do not over-broaden without tests.
+2. Update `packages/next/src/item.ts`:
+   - `WeaverseNextItem` should overlay translations in `getSnapShot()` when `this.weaverse.translationMap?.[this._id]` exists.
+   - Use the same memoization pattern as Hydrogen: cache merged snapshot keyed by `_store` ref and translation entry ref.
+   - No translations → return base `_store` directly.
+3. Update `packages/next/src/runtime.ts`:
+   - Type translation fields with the new types.
+   - `extractTranslationSidecar()` should read from `this.data` and set map/locale/languageId when present; clear to defaults when absent to prevent stale sidecar after route/reuse/project-data changes.
+   - Constructor should call `extractTranslationSidecar()` after `super()` initializes data/items.
+   - `setTranslationSidecar(map, locale, languageId)` should set fields and `refreshAllItems()` like Hydrogen.
+   - `updateTranslation(itemId, key, originalValue, translatedValue)` should:
+     - create per-item map if absent,
+     - assign a new per-item entry object so `getSnapShot()` cache invalidates,
+     - trigger only that item if present.
+   - `getTranslationChanges()` should return undefined unless both `translationLocale` and `translationLanguageId` are set and entries exist.
+     - entries use `key: 'data.<key>'`.
+   - `setProjectData(data)` override should set data, extract sidecar, then `initProject()`.
+   - Runtime reuse branch in `createWeaverseNextRuntime()` should update translation sidecar correctly when fresh page data is applied. Design-mode reuse currently avoids `setProjectData(page)` to avoid clobbering drafts; be careful not to clobber live draft item tree. For design-mode reuse, update only latest payload (`__weaverseNextLatestData`) unless there is a safe reason. For non-design reuse, `setProjectData(page)` should re-extract sidecar via the override.
+4. Tests in `packages/next/__tests__/next-adapter.test.tsx`:
+   - item snapshot overlays `translationMap` `translatedValue` over base `_store`.
+   - no translation returns base snapshot / base values.
+   - memoization: same store + same translation entry returns same object; updating translation creates a new per-item entry and snapshot changes.
+   - `setTranslationSidecar()` updates locale/languageId/map and refreshes items (can assert item subscriber called or snapshot updates after call).
+   - `updateTranslation()` changes only translation map and does not mutate base `_store`; selected snapshot renders translated value; item update subscriber fires.
+   - `getTranslationChanges()` returns expected entries with `data.<key>` and undefined when locale/languageId missing or no entries.
+   - `setProjectData()` clears stale translation sidecar when next page data lacks it.
+   - Runtime reuse non-design applies fresh sidecar via `setProjectData()`. Design-mode reuse should not clobber live item drafts; add/adjust tests only if straightforward.
+5. Update `.specs/2026-06-21--next-studio-bridge/work-logs.md` with this slice.
+
+## Non-goals / guardrails
+
+- Do **not** modify Builder.
+- Do **not** change static-text foundation from PR #488 except if type wiring is required.
+- Do **not** publish npm or update POC in this PR.
+- Keep public/deprecated compatibility from PR #488 intact.
+- Avoid broad refactors or new API surface beyond the types/methods needed for parity.
+- Leave changes uncommitted; Hermes will review, run checks, commit/push/open PR.
+
+## Verification commands
+
+Run at least:
+
+```bash
+pnpm --filter @weaverse/next test -- __tests__/next-adapter.test.tsx
+pnpm --filter @weaverse/next typecheck
+pnpm --filter @weaverse/next build
+pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error
+git diff --check
+```
+
+Report exact commands/results. If the test runner executes the whole package suite, report actual count.

--- a/.specs/2026-06-21--next-studio-bridge/work-logs.md
+++ b/.specs/2026-06-21--next-studio-bridge/work-logs.md
@@ -464,3 +464,69 @@ git diff --check
 ### Notes
 
 Claude implemented the initial source/tests from the handoff but timed out before closeout. Hermes reviewed the partial diff, fixed stale `merchantOverrides` clearing on runtime reuse, added regression coverage for that case, fixed the standalone-provider fallback `TranslationStore` to use `useRef` instead of `useMemo`, corrected translation priority docs, formatted, and ran verification.
+
+## 2026-07-10 — item-level translation sidecar parity
+
+Slice branch: `feat/next-item-translation-sidecar`
+Tracker: https://github.com/Weaverse/builder/issues/2659
+
+Follow-up to PR #488 static-text foundation. This slice implements the item-level/page translation sidecar contract that Builder Studio already uses for Hydrogen.
+
+### Scope
+
+- Added Next item-level translation sidecar types:
+  - `WeaverseNextTranslationMapEntry`
+  - `WeaverseNextTranslationItemEntry`
+  - `WeaverseNextTranslationMap`
+  - `WeaverseNextTranslationEntry`
+  - `WeaverseNextTranslationChanges`
+- `WeaverseNextItem.getSnapShot()` now overlays `runtime.translationMap[itemId][field].translatedValue` over the base `_store`, memoized by `_store` ref + per-item translation entry ref like Hydrogen.
+- `WeaverseNextRuntime` now implements:
+  - `extractTranslationSidecar()` from page data
+  - `setTranslationSidecar(map, locale, languageId)` + item refresh
+  - `updateTranslation(itemId, key, originalValue, translatedValue)` + single-item notify
+  - `getTranslationChanges()` with Builder's `data.<field>` key namespace
+  - `setProjectData()` sidecar re-extraction/clearing on project data replacement
+- Reused non-design runtimes apply fresh sidecars through `setProjectData()`; design-mode runtime reuse still avoids clobbering the live Studio-owned tree/sidecar.
+- No Builder changes.
+
+### Tests
+
+Added `packages/next/__tests__/next-adapter.test.tsx` coverage for:
+
+- snapshot overlay from page `translationMap`
+- base fast path when no translations exist
+- snapshot memoization and invalidation after `updateTranslation()`
+- `setTranslationSidecar()` locale/languageId/map updates and item refresh
+- `updateTranslation()` not mutating base `_store` and firing the item subscriber
+- renderer output using translated values
+- `getTranslationChanges()` output/undefined guards
+- clearing stale sidecar when `setProjectData()` receives data without sidecar
+- non-design runtime reuse applying a fresh sidecar
+- design-mode runtime reuse preserving live Studio translation sidecar edits
+
+### Verification
+
+```bash
+pnpm --filter @weaverse/next test -- __tests__/next-adapter.test.tsx
+# 5 files, 118 tests passed (test runner executed the whole package suite)
+
+pnpm --filter @weaverse/next typecheck
+# passed
+
+pnpm --filter @weaverse/next build
+# passed
+
+pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error
+# passed
+
+git diff --check
+# passed
+
+autoreview-copilot --mode local
+# clean, no accepted/actionable findings
+```
+
+### Notes
+
+Claude implemented the source/tests from the handoff but timed out before closeout. Hermes inspected the diff, fixed formatting/lint, added the work-log, ran verification, and ran autoreview.

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -1957,3 +1957,451 @@ describe('runtime translation bridge', () => {
     vi.stubGlobal('window', previousWindow)
   })
 })
+
+// ─── 9. Item-level translation sidecar ────────────────────────────────
+
+// Parity with Hydrogen's `WeaverseHydrogenItem.getSnapShot()` overlay +
+// `WeaverseHydrogen` sidecar methods. Item IDs are globally unique per test to
+// avoid the process-wide `Weaverse.itemInstances` static map leaking stores
+// across unrelated tests (see the 2026-07-09 work-log pitfall).
+describe('item-level translation sidecar', () => {
+  it('should_overlay_translated_values_from_page_data_over_the_base_store', () => {
+    // Arrange — the loader attached an item-level translation sidecar.
+    let client = makeClient()
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-overlay-page',
+        rootId: 'tr-overlay-item',
+        items: [
+          {
+            id: 'tr-overlay-item',
+            type: 'hero',
+            data: { heading: 'Original' },
+          },
+        ],
+        translationMap: {
+          'tr-overlay-item': {
+            heading: { originalValue: 'Original', translatedValue: 'Traduit' },
+          },
+        },
+        translationLocale: 'fr',
+        translationLanguageId: 'lang-fr',
+      },
+    }
+
+    // Act
+    let runtime = createWeaverseNextRuntime({ client, data })
+    let item = runtime.itemInstances.get('tr-overlay-item')
+    let snapshot = item.getSnapShot()
+
+    // Assert — snapshot carries the translated value; base store is untouched.
+    expect(runtime.translationLocale).toBe('fr')
+    expect(runtime.translationLanguageId).toBe('lang-fr')
+    expect(snapshot.heading).toBe('Traduit')
+    expect(item._store.heading).toBe('Original')
+  })
+
+  it('should_return_the_base_store_snapshot_when_the_item_has_no_translations', () => {
+    // Arrange — no sidecar on the page data.
+    let client = makeClient()
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-none-page',
+        rootId: 'tr-none-item',
+        items: [
+          { id: 'tr-none-item', type: 'hero', data: { heading: 'Base' } },
+        ],
+      },
+    }
+
+    // Act
+    let runtime = createWeaverseNextRuntime({ client, data })
+    let item = runtime.itemInstances.get('tr-none-item')
+
+    // Assert — the fast path returns the base store object itself.
+    expect(runtime.translationMap).toEqual({})
+    expect(item.getSnapShot()).toBe(item._store)
+    expect(item.getSnapShot().heading).toBe('Base')
+  })
+
+  it('should_memoize_the_merged_snapshot_until_the_translation_entry_changes', () => {
+    // Arrange
+    let client = makeClient()
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-memo-page',
+        rootId: 'tr-memo-item',
+        items: [
+          { id: 'tr-memo-item', type: 'hero', data: { heading: 'Original' } },
+        ],
+        translationMap: {
+          'tr-memo-item': {
+            heading: { originalValue: 'Original', translatedValue: 'V1' },
+          },
+        },
+        translationLocale: 'fr',
+        translationLanguageId: 'lang-fr',
+      },
+    }
+    let runtime = createWeaverseNextRuntime({ client, data })
+    let item = runtime.itemInstances.get('tr-memo-item')
+
+    // Act — two reads with nothing changed.
+    let first = item.getSnapShot()
+    let second = item.getSnapShot()
+
+    // Assert — same store + same translation entry → identical object ref.
+    expect(second).toBe(first)
+    expect(first.heading).toBe('V1')
+
+    // Act — editing the field assigns a fresh per-item entry (cache invalidates).
+    runtime.updateTranslation('tr-memo-item', 'heading', 'Original', 'V2')
+    let third = item.getSnapShot()
+
+    // Assert — new object, new value.
+    expect(third).not.toBe(first)
+    expect(third.heading).toBe('V2')
+  })
+
+  it('should_set_locale_and_refresh_items_when_setTranslationSidecar_is_called', () => {
+    // Arrange — start with no sidecar, subscribe to the item.
+    let client = makeClient()
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-set-page',
+        rootId: 'tr-set-item',
+        items: [
+          { id: 'tr-set-item', type: 'hero', data: { heading: 'Original' } },
+        ],
+      },
+    }
+    let runtime = createWeaverseNextRuntime({ client, data })
+    let item = runtime.itemInstances.get('tr-set-item')
+    let listener = vi.fn()
+    let unsubscribe = item.subscribe(listener)
+
+    // Act
+    runtime.setTranslationSidecar(
+      {
+        'tr-set-item': {
+          heading: { originalValue: 'Original', translatedValue: 'Neu' },
+        },
+      },
+      'de',
+      'lang-de'
+    )
+    unsubscribe()
+
+    // Assert — locale/languageId/map applied, item refreshed, snapshot updated.
+    expect(runtime.translationLocale).toBe('de')
+    expect(runtime.translationLanguageId).toBe('lang-de')
+    expect(listener).toHaveBeenCalled()
+    expect(item.getSnapShot().heading).toBe('Neu')
+  })
+
+  it('should_update_only_the_translation_map_and_fire_the_item_subscriber', () => {
+    // Arrange
+    let client = makeClient()
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-update-page',
+        rootId: 'tr-update-item',
+        items: [
+          { id: 'tr-update-item', type: 'hero', data: { heading: 'Original' } },
+        ],
+        translationMap: {},
+        translationLocale: 'fr',
+        translationLanguageId: 'lang-fr',
+      },
+    }
+    let runtime = createWeaverseNextRuntime({ client, data })
+    let item = runtime.itemInstances.get('tr-update-item')
+    let listener = vi.fn()
+    let unsubscribe = item.subscribe(listener)
+
+    // Act
+    runtime.updateTranslation(
+      'tr-update-item',
+      'heading',
+      'Original',
+      'Traduit'
+    )
+    unsubscribe()
+
+    // Assert — base store untouched, map holds the entry, subscriber fired once,
+    // and the merged snapshot renders the translated value.
+    expect(item._store.heading).toBe('Original')
+    expect(runtime.translationMap['tr-update-item'].heading).toEqual({
+      originalValue: 'Original',
+      translatedValue: 'Traduit',
+    })
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(item.getSnapShot().heading).toBe('Traduit')
+  })
+
+  it('should_render_translated_values_through_the_page_renderer', () => {
+    // Arrange — a hero whose heading is translated via the page sidecar.
+    let client = makeClient()
+    client.data = {
+      page: {
+        id: 'tr-render-overlay-page',
+        rootId: 'tr-render-overlay-item',
+        items: [
+          {
+            id: 'tr-render-overlay-item',
+            type: 'hero',
+            data: { heading: 'Original heading' },
+          },
+        ],
+        translationMap: {
+          'tr-render-overlay-item': {
+            heading: {
+              originalValue: 'Original heading',
+              translatedValue: 'Titre traduit',
+            },
+          },
+        },
+        translationLocale: 'fr',
+        translationLanguageId: 'lang-fr',
+      },
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextProvider client={client}>
+        <WeaverseNextRenderer />
+      </WeaverseNextProvider>
+    )
+
+    // Assert — the overlay reaches the rendered output; the base copy is gone.
+    expect(html).toContain('Titre traduit')
+    expect(html).not.toContain('Original heading')
+  })
+
+  it('should_collect_translation_changes_with_data_prefixed_keys', () => {
+    // Arrange
+    let client = makeClient()
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-changes-page',
+        rootId: 'tr-changes-item',
+        items: [{ id: 'tr-changes-item', type: 'hero', data: {} }],
+      },
+    }
+    let runtime = createWeaverseNextRuntime({ client, data })
+    runtime.setTranslationSidecar(
+      {
+        'tr-changes-item': {
+          heading: { originalValue: 'Original', translatedValue: 'Traduit' },
+        },
+      },
+      'fr',
+      'lang-fr'
+    )
+
+    // Act
+    let changes = runtime.getTranslationChanges()
+
+    // Assert — entries carry the `data.<field>` key namespace Builder expects.
+    expect(changes).toEqual({
+      languageId: 'lang-fr',
+      entries: [
+        {
+          itemId: 'tr-changes-item',
+          key: 'data.heading',
+          originalValue: 'Original',
+          translatedValue: 'Traduit',
+        },
+      ],
+    })
+  })
+
+  it('should_return_undefined_translation_changes_when_locale_language_or_entries_missing', () => {
+    // Arrange
+    let client = makeClient()
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-empty-changes-page',
+        rootId: 'tr-empty-changes-item',
+        items: [{ id: 'tr-empty-changes-item', type: 'hero', data: {} }],
+      },
+    }
+    let runtime = createWeaverseNextRuntime({ client, data })
+
+    // Assert — no locale/languageId and no entries → undefined.
+    expect(runtime.getTranslationChanges()).toBeUndefined()
+
+    // Act — locale + languageId set, but the map is still empty.
+    runtime.setTranslationSidecar({}, 'fr', 'lang-fr')
+
+    // Assert — empty entries → undefined.
+    expect(runtime.getTranslationChanges()).toBeUndefined()
+
+    // Act — a map entry exists, but the languageId is missing.
+    runtime.setTranslationSidecar(
+      {
+        'tr-empty-changes-item': {
+          heading: { originalValue: 'a', translatedValue: 'b' },
+        },
+      },
+      'fr',
+      ''
+    )
+
+    // Assert — missing languageId → undefined even with entries.
+    expect(runtime.getTranslationChanges()).toBeUndefined()
+  })
+
+  it('should_clear_a_stale_sidecar_when_setProjectData_gets_page_data_without_one', () => {
+    // Arrange — a runtime that started with a translation sidecar.
+    let client = makeClient()
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-clear-page',
+        rootId: 'tr-clear-item',
+        items: [{ id: 'tr-clear-item', type: 'hero', data: {} }],
+        translationMap: {
+          'tr-clear-item': {
+            heading: { originalValue: 'a', translatedValue: 'b' },
+          },
+        },
+        translationLocale: 'fr',
+        translationLanguageId: 'lang-fr',
+      },
+    }
+    let runtime = createWeaverseNextRuntime({ client, data })
+    expect(runtime.translationLocale).toBe('fr')
+
+    // Act — replace with fresh page data that carries no sidecar.
+    runtime.setProjectData({
+      id: 'tr-clear-page',
+      rootId: 'tr-clear-item',
+      items: [{ id: 'tr-clear-item', type: 'hero', data: {} }],
+    })
+
+    // Assert — the stale sidecar is cleared to defaults.
+    expect(runtime.translationMap).toEqual({})
+    expect(runtime.translationLocale).toBe('')
+    expect(runtime.translationLanguageId).toBe('')
+  })
+
+  it('should_apply_a_fresh_sidecar_through_setProjectData_on_non_design_reuse', () => {
+    // Arrange — published/non-design reuse: same page ID + URL across two passes.
+    let previousWindow = globalThis.window
+    let fakeWindow = {} as Window &
+      typeof globalThis & { __weaverses?: unknown }
+    vi.stubGlobal('window', fakeWindow)
+    let client = makeClient({
+      requestContext: { isDesignMode: false, pathname: '/' },
+    })
+    let firstData: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-reuse-side-page',
+        rootId: 'tr-reuse-side-item',
+        items: [
+          {
+            id: 'tr-reuse-side-item',
+            type: 'hero',
+            data: { heading: 'Original' },
+          },
+        ],
+      },
+    }
+    let runtime = createWeaverseNextRuntime({ client, data: firstData })
+    expect(runtime.translationMap).toEqual({})
+    let secondData: WeaverseNextLoaderData = {
+      page: {
+        id: 'tr-reuse-side-page',
+        rootId: 'tr-reuse-side-item',
+        items: [
+          {
+            id: 'tr-reuse-side-item',
+            type: 'hero',
+            data: { heading: 'Original' },
+          },
+        ],
+        translationMap: {
+          'tr-reuse-side-item': {
+            heading: { originalValue: 'Original', translatedValue: 'Traduit' },
+          },
+        },
+        translationLocale: 'fr',
+        translationLanguageId: 'lang-fr',
+      },
+    }
+
+    // Act — non-design reuse re-applies project data (and its sidecar).
+    let reused = createWeaverseNextRuntime({ client, data: secondData })
+
+    // Assert — same runtime, fresh sidecar extracted, item overlays it.
+    expect(reused).toBe(runtime)
+    expect(reused.translationLocale).toBe('fr')
+    expect(
+      reused.translationMap['tr-reuse-side-item'].heading.translatedValue
+    ).toBe('Traduit')
+    let item = reused.itemInstances.get('tr-reuse-side-item')
+    expect(item.getSnapShot().heading).toBe('Traduit')
+    vi.stubGlobal('window', previousWindow)
+  })
+
+  it('should_not_clobber_a_live_sidecar_when_reusing_a_design_mode_runtime', () => {
+    // Arrange — a live design-mode runtime owns its translation sidecar; Builder
+    // pushes edits via setTranslationSidecar/updateTranslation, so a reuse pass
+    // with fresh loader data must not overwrite the live map.
+    let previousWindow = globalThis.window
+    let fakeWindow = {} as Window &
+      typeof globalThis & { __weaverses?: unknown }
+    vi.stubGlobal('window', fakeWindow)
+    let client = makeClient({
+      requestContext: { isDesignMode: true, pathname: '/' },
+    })
+    let runtime = createWeaverseNextRuntime({
+      client,
+      data: {
+        page: {
+          id: 'tr-design-reuse-page',
+          rootId: 'tr-design-reuse-item',
+          items: [{ id: 'tr-design-reuse-item', type: 'hero', data: {} }],
+        },
+      },
+    })
+    // Builder pushes a live translation edit into the running runtime.
+    runtime.updateTranslation(
+      'tr-design-reuse-item',
+      'heading',
+      'Original',
+      'Live edit'
+    )
+    let setProjectData = vi.spyOn(runtime, 'setProjectData')
+
+    // Act — a reuse pass arrives with fresh loader data carrying its own sidecar.
+    let reused = createWeaverseNextRuntime({
+      client,
+      data: {
+        page: {
+          id: 'tr-design-reuse-page',
+          rootId: 'tr-design-reuse-item',
+          items: [{ id: 'tr-design-reuse-item', type: 'hero', data: {} }],
+          translationMap: {
+            'tr-design-reuse-item': {
+              heading: {
+                originalValue: 'Original',
+                translatedValue: 'Server value',
+              },
+            },
+          },
+          translationLocale: 'fr',
+          translationLanguageId: 'lang-fr',
+        },
+      },
+    })
+
+    // Assert — same runtime, project data not reset, live edit preserved.
+    expect(reused).toBe(runtime)
+    expect(setProjectData).not.toHaveBeenCalled()
+    expect(
+      reused.translationMap['tr-design-reuse-item'].heading.translatedValue
+    ).toBe('Live edit')
+    vi.stubGlobal('window', previousWindow)
+  })
+})

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -119,6 +119,11 @@ export type {
   WeaverseNextRuntimeInternal,
   WeaverseNextStorefront,
   WeaverseNextThemeSettingsStore,
+  WeaverseNextTranslationChanges,
+  WeaverseNextTranslationEntry,
+  WeaverseNextTranslationItemEntry,
+  WeaverseNextTranslationMap,
+  WeaverseNextTranslationMapEntry,
   WeaverseProduct,
 } from './types'
 export {

--- a/packages/next/src/item.ts
+++ b/packages/next/src/item.ts
@@ -1,6 +1,10 @@
 import type { ElementData } from '@weaverse/react'
 import { Weaverse, WeaverseItemStore } from '@weaverse/react'
-import type { WeaverseNextComponentData } from './types'
+import type { WeaverseNextRuntime } from './runtime'
+import type {
+  WeaverseNextComponentData,
+  WeaverseNextTranslationItemEntry,
+} from './types'
 import { generateDataFromSchema } from './utils'
 
 /**
@@ -9,11 +13,61 @@ import { generateDataFromSchema } from './utils'
  * shared `@weaverse/react` renderer can spread props at the top level.
  */
 export class WeaverseNextItem extends WeaverseItemStore {
+  declare weaverse: WeaverseNextRuntime
+
+  /**
+   * Cached merged snapshot (base `_store` + translations). Reset whenever the
+   * `_store` ref or the item's translation entry ref changes, so
+   * `useSyncExternalStore` sees a stable object between unrelated re-renders.
+   */
+  private _cachedSnapshot: ElementData | null = null
+  private _snapshotStoreRef: ElementData | null = null
+  private _snapshotTranslationRef: WeaverseNextTranslationItemEntry | null =
+    null
+
   constructor(initialData: WeaverseNextComponentData, weaverse: Weaverse) {
     super(initialData as ElementData, weaverse)
     let { data, ...rest } = initialData
     let schemaData = generateDataFromSchema(this.Element?.schema)
     Object.assign(this._store, schemaData, data, rest)
+  }
+
+  /**
+   * Overlay item-level translations onto the base store when the runtime is in
+   * translation mode. Mirrors Hydrogen's `WeaverseHydrogenItem.getSnapShot()`:
+   * memoized by `_store` ref + translation entry ref so the returned object is
+   * referentially stable, and a fast path that returns the base store untouched
+   * when the item has no translations.
+   */
+  getSnapShot = (): ElementData => {
+    let base = this._store
+    let translations = this.weaverse.translationMap[this._id]
+
+    // No translations → return the base store directly (fast path).
+    if (!translations) {
+      return base
+    }
+
+    // Reuse the cached merge while both the store and translation refs hold.
+    if (
+      this._cachedSnapshot &&
+      this._snapshotStoreRef === base &&
+      this._snapshotTranslationRef === translations
+    ) {
+      return this._cachedSnapshot
+    }
+
+    let merged = { ...base }
+    for (let [key, entry] of Object.entries(translations)) {
+      if (entry.translatedValue !== undefined) {
+        merged[key] = entry.translatedValue
+      }
+    }
+
+    this._cachedSnapshot = merged
+    this._snapshotStoreRef = base
+    this._snapshotTranslationRef = translations
+    return merged
   }
 }
 

--- a/packages/next/src/runtime.ts
+++ b/packages/next/src/runtime.ts
@@ -10,6 +10,9 @@ import type {
   WeaverseNextRequestInfo,
   WeaverseNextRuntimeConfig,
   WeaverseNextRuntimeInternal,
+  WeaverseNextTranslationChanges,
+  WeaverseNextTranslationEntry,
+  WeaverseNextTranslationMap,
 } from './types'
 
 declare global {
@@ -107,7 +110,14 @@ export class WeaverseNextRuntime extends Weaverse {
   isPreviewMode: boolean
   isRevisionPreview: boolean
   sectionType?: string
-  translationMap: Record<string, unknown> = {}
+
+  // ─── Item-level translation sidecar (design mode only) ─────────────
+  /**
+   * Translation map received from Builder in design mode, keyed by item ID.
+   * `WeaverseNextItem.getSnapShot()` overlays these onto the data handed to
+   * components, so translations render without mutating the base `_store`.
+   */
+  translationMap: WeaverseNextTranslationMap = {}
   translationLocale = ''
   translationLanguageId = ''
 
@@ -156,20 +166,117 @@ export class WeaverseNextRuntime extends Weaverse {
       translationStore,
       themeTextStore: translationStore,
     }
+
+    // Read any item-level translation sidecar the loader attached to the page
+    // data. Runs after `super()` has built `this.data` and the item stores.
+    this.extractTranslationSidecar()
   }
 
-  extractTranslationSidecar = () => undefined
+  /**
+   * Pull `translationMap` / `translationLocale` / `translationLanguageId` off
+   * the current page data (Builder attaches them in design mode). Unlike
+   * Hydrogen, this also clears the sidecar to defaults when the new page data
+   * carries none, so a reused runtime / project-data swap can't leave a stale
+   * map overlaying the fresh tree.
+   */
+  extractTranslationSidecar = () => {
+    let pageData = this.data as WeaverseNextPageData | undefined
+    let translationMap = pageData?.translationMap as
+      | WeaverseNextTranslationMap
+      | undefined
+    if (translationMap) {
+      this.translationMap = translationMap
+      this.translationLocale = (pageData?.translationLocale as string) || ''
+      this.translationLanguageId =
+        (pageData?.translationLanguageId as string) || ''
+    } else {
+      this.translationMap = {}
+      this.translationLocale = ''
+      this.translationLanguageId = ''
+    }
+  }
+
+  /**
+   * Replace the translation sidecar (Builder pushes this when translation data
+   * arrives or the active language changes) and refresh every item so their
+   * merged snapshots recompute.
+   */
   setTranslationSidecar = (
-    map: Record<string, unknown> = {},
+    map: WeaverseNextTranslationMap = {},
     locale = '',
     languageId = ''
   ) => {
     this.translationMap = map
     this.translationLocale = locale
     this.translationLanguageId = languageId
+    this.refreshAllItems()
   }
-  updateTranslation = () => undefined
-  getTranslationChanges = () => undefined
+
+  /**
+   * Update a single translatable field for one item. Assigns a new per-item
+   * entry object so `WeaverseNextItem.getSnapShot()`'s translation-ref cache
+   * invalidates, then triggers only that item's subscribers.
+   */
+  updateTranslation = (
+    itemId: string,
+    key: string,
+    originalValue: string,
+    translatedValue: string
+  ) => {
+    if (!this.translationMap[itemId]) {
+      this.translationMap[itemId] = {}
+    }
+    // New entry reference so the item's snapshot cache detects the change.
+    this.translationMap[itemId] = {
+      ...this.translationMap[itemId],
+      [key]: { originalValue, translatedValue },
+    }
+    let instance = this.itemInstances.get(itemId)
+    if (instance) {
+      instance.triggerUpdate()
+    }
+  }
+
+  /**
+   * Collect translation changes for the save flow. Returns `undefined` unless
+   * both the locale and language ID are set and at least one entry exists;
+   * each entry key is namespaced as `data.<field>` to match Builder.
+   */
+  getTranslationChanges = (): WeaverseNextTranslationChanges | undefined => {
+    let languageId = this.translationLanguageId
+    if (!(this.translationLocale && languageId)) {
+      return
+    }
+
+    let entries: WeaverseNextTranslationEntry[] = []
+    for (let [itemId, fields] of Object.entries(this.translationMap)) {
+      for (let [key, entry] of Object.entries(fields)) {
+        entries.push({
+          itemId,
+          key: `data.${key}`,
+          originalValue: entry.originalValue,
+          translatedValue: entry.translatedValue,
+        })
+      }
+    }
+
+    if (entries.length === 0) {
+      return
+    }
+    return { languageId, entries }
+  }
+
+  /**
+   * Re-extract the translation sidecar whenever project data is replaced (route
+   * change / non-design reuse), before rebuilding item stores. Takes the
+   * renderable page shape (`rootId` resolved) that `getRenderablePage()` and
+   * the reuse branch pass in.
+   */
+  setProjectData = (data: WeaverseNextPageData & { rootId: string }) => {
+    this.data = data
+    this.extractTranslationSidecar()
+    this.initProject()
+  }
 }
 
 export function createWeaverseNextRuntime(

--- a/packages/next/src/runtime.ts
+++ b/packages/next/src/runtime.ts
@@ -118,8 +118,8 @@ export class WeaverseNextRuntime extends Weaverse {
    * components, so translations render without mutating the base `_store`.
    */
   translationMap: WeaverseNextTranslationMap = {}
-  translationLocale = ''
-  translationLanguageId = ''
+  translationLocale = String()
+  translationLanguageId = String()
 
   constructor(config: WeaverseNextRuntimeConfig) {
     let { client, data } = config

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -104,7 +104,7 @@ export interface WeaverseNextTranslationMapEntry {
 }
 
 /** Per-item translation fields, keyed by field name. */
-export type WeaverseNextTranslationItemEntry = {
+export interface WeaverseNextTranslationItemEntry {
   [key: string]: WeaverseNextTranslationMapEntry
 }
 
@@ -112,7 +112,7 @@ export type WeaverseNextTranslationItemEntry = {
  * Translation map sent from Builder alongside page data in design mode.
  * Keyed by item ID, each value maps field names to translation entries.
  */
-export type WeaverseNextTranslationMap = {
+export interface WeaverseNextTranslationMap {
   [itemId: string]: WeaverseNextTranslationItemEntry
 }
 
@@ -126,9 +126,9 @@ export interface WeaverseNextTranslationEntry {
 }
 
 /** Result of collecting translation changes for the save flow. */
-export type WeaverseNextTranslationChanges = {
-  languageId: string
+export interface WeaverseNextTranslationChanges {
   entries: WeaverseNextTranslationEntry[]
+  languageId: string
 }
 
 /**

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -89,6 +89,48 @@ export interface WeaverseNextRuntimeConfig {
   translationStore?: TranslationStore
 }
 
+// ─── Item-level translation sidecar types (design mode) ──────────────
+//
+// Kept structurally aligned with Hydrogen's `TranslationMapEntry` /
+// `TranslationItemEntry` / `TranslationMap` / `TranslationEntry` /
+// `TranslationChanges` so Builder Studio's item-translation RPC contract works
+// against `@weaverse/next` unchanged. Values stay strings for now; broaden to
+// object values only when Builder image handling forces it (with tests).
+
+/** A single translated field for one item. */
+export interface WeaverseNextTranslationMapEntry {
+  originalValue: string
+  translatedValue: string
+}
+
+/** Per-item translation fields, keyed by field name. */
+export type WeaverseNextTranslationItemEntry = {
+  [key: string]: WeaverseNextTranslationMapEntry
+}
+
+/**
+ * Translation map sent from Builder alongside page data in design mode.
+ * Keyed by item ID, each value maps field names to translation entries.
+ */
+export type WeaverseNextTranslationMap = {
+  [itemId: string]: WeaverseNextTranslationItemEntry
+}
+
+/** A single translation entry for save payloads. */
+export interface WeaverseNextTranslationEntry {
+  deleted?: boolean
+  itemId: string
+  key: string
+  originalValue: string
+  translatedValue: string
+}
+
+/** Result of collecting translation changes for the save flow. */
+export type WeaverseNextTranslationChanges = {
+  languageId: string
+  entries: WeaverseNextTranslationEntry[]
+}
+
 /**
  * Locale/market info passed through to component loaders and the Storefront
  * client. Kept structurally close to Hydrogen's `WeaverseI18n` but without the


### PR DESCRIPTION
## Summary
- add Next item-level translation sidecar types and exports
- overlay item translation values in `WeaverseNextItem.getSnapShot()` without mutating base `_store`
- implement runtime sidecar methods: `extractTranslationSidecar`, `setTranslationSidecar`, `updateTranslation`, `getTranslationChanges`, `setProjectData`
- cover non-design runtime reuse and design-mode live sidecar preservation

## Verification
- `pnpm --filter @weaverse/next test -- __tests__/next-adapter.test.tsx` — 5 files, 118 tests passed
- `pnpm --filter @weaverse/next typecheck` — passed
- `pnpm --filter @weaverse/next build` — passed
- `pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md --diagnostic-level=error` — passed
- `git diff --check` — passed
- autoreview-copilot — clean
