### PR TITLE
Hide Shopify Chat widget while overlays are open

### DIFF
--- a/.weaverse/docs/shopify-inbox.md
+++ b/.weaverse/docs/shopify-inbox.md
@@ -110,6 +110,53 @@ import { openShopifyInbox } from "~/components/shopify-inbox";
 
 `openShopifyInbox()` opens the widget whatever state it is in: it clicks the loader's placeholder bubble (`#dummy-chat-button`, inside the same-origin `#dummy-chat-button-iframe`) for first-time visitors, or the `[data-spec="toggle-button"]` launcher inside the `<inbox-online-store-chat>` web component's shadow root once the full widget has loaded (skipping the click when the chat is already open, since that launcher toggles). It returns `true` when a launcher was found and clicked or the chat is already open, `false` otherwise (the widget has not rendered yet, or Inbox is not configured). These selectors are **Shopify-internal and undocumented** — they can change when Shopify updates the chat widget.
 
+## Hiding the chat during overlays
+
+Drawers, popups, and modals should hide Shopify Inbox so its floating launcher
+or open chat panel cannot cover storefront content. For Radix dialogs, render
+`ShopifyInboxOverlayGuard` inside `Dialog.Content`:
+
+```tsx
+import * as Dialog from "@radix-ui/react-dialog";
+import { ShopifyInboxOverlayGuard } from "~/components/shopify-inbox";
+
+<Dialog.Content>
+  <ShopifyInboxOverlayGuard />
+  {/* Dialog content */}
+</Dialog.Content>;
+```
+
+The guard renders no DOM. It hides Inbox when the dialog content mounts and
+shows it again after the content unmounts, including after Radix's closing
+animation. Visibility requests are reference-counted, so closing one of several
+nested or overlapping dialogs does not reveal Inbox while another remains open.
+
+For an overlay that stays mounted and controls visibility with state (for
+example, a `forceMount` portal), use the imperative helper and return its
+cleanup function from an effect:
+
+```tsx
+import { useEffect } from "react";
+import { hideShopifyInbox } from "~/components/shopify-inbox";
+
+useEffect(() => {
+  if (open) {
+    return hideShopifyInbox();
+  }
+}, [open]);
+```
+
+The helper is safe when Inbox is not configured or has not mounted yet. It sets
+`data-shopify-inbox-hidden` on the document root; global CSS hides both the
+loader's placeholder iframe and the loaded `#shopify-chat` wrapper. A
+`visibility: hidden` fallback targets `<inbox-online-store-chat>` directly
+because Shopify's shadow stylesheet forces `:host { display: block !important; }`,
+which light-DOM `display` rules cannot override. Because the selectors are
+state-based, a widget injected after an overlay opens is hidden immediately
+without polling or a mutation observer. Hiding the loaded widget also
+temporarily hides an already-open chat panel while preserving its internal state
+for when the overlay closes.
+
 ## Limitations
 
 - **Localhost:** Shopify's bot protection blocks the widget on `localhost`. The loader `<script>` is still injected (after `load`), but the chat UI will not initialize. Verify on a deployed (staging/production) domain.

--- a/app/components/cart/cart-drawer.tsx
+++ b/app/components/cart/cart-drawer.tsx
@@ -6,6 +6,7 @@ import { useLocation } from "react-router";
 import { CartMain } from "~/components/cart/cart-main";
 import { Icon } from "~/components/icon";
 import Link from "~/components/link";
+import { ShopifyInboxOverlayGuard } from "~/components/shopify-inbox";
 import { Spinner } from "~/components/spinner";
 import { useCart, useCartBootstrapResolved, useCartStore } from "./store";
 
@@ -69,6 +70,7 @@ export function CartDrawer() {
           )}
           aria-describedby={undefined}
         >
+          <ShopifyInboxOverlayGuard />
           <div className="flex h-full flex-col space-y-6">
             <div className="flex items-center justify-between gap-2 px-4">
               <Dialog.Title asChild className="text-base">

--- a/app/components/cart/cart-summary-actions.tsx
+++ b/app/components/cart/cart-summary-actions.tsx
@@ -6,6 +6,7 @@ import type { CartApiQueryFragment } from "storefront-api.generated";
 import { Banner } from "~/components/banner";
 import { Button } from "~/components/button";
 import { Icon } from "~/components/icon";
+import { ShopifyInboxOverlayGuard } from "~/components/shopify-inbox";
 import { usePrefixPathWithLocale } from "~/hooks/use-prefix-path-with-locale";
 import { cn } from "~/utils/cn";
 import { useCartFetcherSync } from "./store";
@@ -57,6 +58,7 @@ export function NoteDialog({ cartNote: currentNote }: { cartNote: string }) {
         )}
         aria-describedby={undefined}
       >
+        <ShopifyInboxOverlayGuard />
         <div className="relative w-full max-w-md overflow-hidden rounded-lg bg-white p-6 shadow-xl">
           <Dialog.Close asChild>
             <button
@@ -160,6 +162,7 @@ export function DiscountDialog({
         )}
         aria-describedby={undefined}
       >
+        <ShopifyInboxOverlayGuard />
         <div className="relative w-full max-w-md overflow-hidden rounded-lg bg-white p-6 shadow-xl">
           <Dialog.Close asChild>
             <button
@@ -269,6 +272,7 @@ export function GiftCardDialog({
         )}
         aria-describedby={undefined}
       >
+        <ShopifyInboxOverlayGuard />
         <div className="relative w-full max-w-md overflow-hidden rounded-lg bg-white p-6 shadow-xl">
           <Dialog.Close asChild>
             <button

--- a/app/components/layout/menu/mobile-menu.tsx
+++ b/app/components/layout/menu/mobile-menu.tsx
@@ -3,6 +3,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { Icon } from "~/components/icon";
 import Link from "~/components/link";
 import { ScrollArea } from "~/components/scroll-area";
+import { ShopifyInboxOverlayGuard } from "~/components/shopify-inbox";
 import { useShopMenu } from "~/hooks/use-shop-menu";
 import type { SingleMenuItem } from "~/types/menu";
 import { cn } from "~/utils/cn";
@@ -40,6 +41,7 @@ export function MobileMenu() {
           ])}
           aria-describedby={undefined}
         >
+          <ShopifyInboxOverlayGuard />
           <Dialog.Title asChild>
             <div className="px-4">Menu</div>
           </Dialog.Title>

--- a/app/components/layout/predictive-search/index.tsx
+++ b/app/components/layout/predictive-search/index.tsx
@@ -4,6 +4,7 @@ import { type RefObject, useEffect, useState } from "react";
 import { useLocation, useParams } from "react-router";
 import { Icon } from "~/components/icon";
 import Link from "~/components/link";
+import { ShopifyInboxOverlayGuard } from "~/components/shopify-inbox";
 import { usePredictiveSearch } from "~/hooks/use-predictive-search";
 import { cn } from "~/utils/cn";
 import { PopularKeywords } from "./popular-keywords";
@@ -48,6 +49,7 @@ export function PredictiveSearchButton() {
           )}
           aria-describedby={undefined}
         >
+          <ShopifyInboxOverlayGuard />
           <VisuallyHidden.Root asChild>
             <Dialog.Title>Predictive search</Dialog.Title>
           </VisuallyHidden.Root>

--- a/app/components/product-card/quick-shop.tsx
+++ b/app/components/product-card/quick-shop.tsx
@@ -18,6 +18,7 @@ import { Quantity } from "~/components/product/quantity";
 import { VariantPrices } from "~/components/product/variant-prices";
 import { VariantSelector } from "~/components/product/variant-selector";
 import { ProductMedia } from "~/components/product-media";
+import { ShopifyInboxOverlayGuard } from "~/components/shopify-inbox";
 import { Skeleton } from "~/components/skeleton";
 import JudgemeStarsRating from "~/sections/main-product/judgeme-stars-rating";
 import type { ThemeSettings } from "~/types/weaverse";
@@ -236,6 +237,7 @@ export function QuickShopTrigger({
           }}
           aria-describedby={undefined}
         >
+          <ShopifyInboxOverlayGuard />
           <div
             style={{ maxHeight: "90vh" }}
             className={clsx(

--- a/app/components/product-media/media-zoom.tsx
+++ b/app/components/product-media/media-zoom.tsx
@@ -14,6 +14,7 @@ import { Button } from "~/components/button";
 import { Icon } from "~/components/icon";
 import { Image } from "~/components/image";
 import { ScrollArea } from "~/components/scroll-area";
+import { ShopifyInboxOverlayGuard } from "~/components/shopify-inbox";
 import { Spinner } from "~/components/spinner";
 import { cn } from "~/utils/cn";
 import { calculateAspectRatio } from "~/utils/image";
@@ -110,6 +111,7 @@ export function ZoomModal({
           ])}
           aria-describedby={undefined}
         >
+          <ShopifyInboxOverlayGuard />
           <div className="relative flex h-full w-full items-center justify-center bg-background">
             <VisuallyHidden.Root asChild>
               <Dialog.Title>Product media zoom</Dialog.Title>

--- a/app/components/root/newsletter-popup.tsx
+++ b/app/components/root/newsletter-popup.tsx
@@ -7,6 +7,7 @@ import { Banner } from "~/components/banner";
 import { Button } from "~/components/button";
 import { Icon } from "~/components/icon";
 import { Image } from "~/components/image";
+import { ShopifyInboxOverlayGuard } from "~/components/shopify-inbox";
 import { useWeaverseStudioCheck } from "~/hooks/use-weaverse-studio-check";
 import type { RootLoader } from "~/root";
 import type { ThemeSettings } from "~/types/weaverse";
@@ -133,6 +134,7 @@ export function NewsletterPopup() {
           )}
           aria-describedby={undefined}
         >
+          <ShopifyInboxOverlayGuard />
           <div
             className={cn(
               "relative w-full overflow-hidden rounded-lg bg-white",

--- a/app/components/shopify-inbox.tsx
+++ b/app/components/shopify-inbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 
 type ShopifyInboxButton = {
   /** Button color as a hex value, e.g. `#000000`. */
@@ -67,6 +67,15 @@ const LOADER_BASE_URL =
   "https://cdn.shopify.com/shopifycloud/shopify_chat/storefront";
 
 const SCRIPT_ID = "shopify-inbox";
+const HIDDEN_ATTRIBUTE = "data-shopify-inbox-hidden";
+
+// Each mounted overlay owns one token. The widget is shown again only after
+// every owner releases its token, so nested/overlapping dialogs cannot reveal
+// the launcher while another overlay is still open.
+const hiddenRequests = new Set<symbol>();
+
+const useHydrationSafeLayoutEffect =
+  typeof document === "undefined" ? useEffect : useLayoutEffect;
 
 // Shopify-internal (undocumented) selectors for the chat launcher; they could
 // change if Shopify updates the chat widget. Before the widget bundle loads the
@@ -144,6 +153,55 @@ export function ShopifyInbox({
     return () => window.removeEventListener("load", injectLoader);
   }, [src]);
 
+  return null;
+}
+
+function syncShopifyInboxVisibility() {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.documentElement.toggleAttribute(
+    HIDDEN_ATTRIBUTE,
+    hiddenRequests.size > 0,
+  );
+}
+
+/**
+ * Hides Shopify Inbox until the returned cleanup function is called.
+ *
+ * The request is reference-counted, so it is safe for nested or overlapping
+ * overlays. It also degrades gracefully when Inbox is not configured or has
+ * not mounted yet: CSS keyed by `HIDDEN_ATTRIBUTE` applies when Shopify later
+ * injects its placeholder iframe or loaded web component.
+ */
+export function hideShopifyInbox(): () => void {
+  if (typeof document === "undefined") {
+    return () => undefined;
+  }
+
+  const request = Symbol("shopify-inbox-hidden");
+  hiddenRequests.add(request);
+  syncShopifyInboxVisibility();
+
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    hiddenRequests.delete(request);
+    syncShopifyInboxVisibility();
+  };
+}
+
+/**
+ * Keeps Shopify Inbox hidden for the lifetime of an overlay's content.
+ * Place this inside `Dialog.Content` so Radix Presence retains the guard until
+ * the closing animation finishes. Renders no DOM.
+ */
+export function ShopifyInboxOverlayGuard() {
+  useHydrationSafeLayoutEffect(() => hideShopifyInbox(), []);
   return null;
 }
 

--- a/app/routes/account/layout.tsx
+++ b/app/routes/account/layout.tsx
@@ -7,6 +7,7 @@ import type { LoaderFunctionArgs } from "react-router";
 import { data, Outlet, useLoaderData, useMatches } from "react-router";
 import { Icon } from "~/components/icon";
 import Link from "~/components/link";
+import { ShopifyInboxOverlayGuard } from "~/components/shopify-inbox";
 import { routeHeaders } from "~/utils/cache";
 import { getFeaturedProducts } from "~/utils/featured-products";
 import { doLogout } from "./auth/logout";
@@ -73,6 +74,7 @@ export default function AccountLayout() {
               ])}
               aria-describedby={undefined}
             >
+              <ShopifyInboxOverlayGuard />
               <div className="relative w-125 max-w-[90vw] rounded-lg bg-background px-6 py-3">
                 <VisuallyHidden.Root asChild>
                   <Dialog.Title>Account modal</Dialog.Title>

--- a/app/sections/judgeme-reviews/review-item.tsx
+++ b/app/sections/judgeme-reviews/review-item.tsx
@@ -3,6 +3,7 @@ import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { useState } from "react";
 import { Icon } from "~/components/icon";
 import { Image } from "~/components/image";
+import { ShopifyInboxOverlayGuard } from "~/components/shopify-inbox";
 import { StarRating } from "~/components/star-rating";
 import type { JudgeMeReviewType, JudgemeReviewImage } from "~/types/judgeme";
 import { cn } from "~/utils/cn";
@@ -160,6 +161,7 @@ export function ReviewImagesModal({
           )}
           aria-describedby={undefined}
         >
+          <ShopifyInboxOverlayGuard />
           <VisuallyHidden.Root asChild>
             <Dialog.Title>Review image gallery</Dialog.Title>
           </VisuallyHidden.Root>

--- a/app/sections/main-collection/toolbar/index.tsx
+++ b/app/sections/main-collection/toolbar/index.tsx
@@ -10,6 +10,7 @@ import { Icon } from "~/components/icon";
 import { SortDropdown } from "~/components/product-grid/sort-dropdown";
 import { useProductGridStore } from "~/components/product-grid/store";
 import { ScrollArea } from "~/components/scroll-area";
+import { ShopifyInboxOverlayGuard } from "~/components/shopify-inbox";
 import type { SortParam } from "~/types/others";
 import { cn } from "~/utils/cn";
 import { Filters, type FiltersProps } from "../filters/filters";
@@ -53,6 +54,7 @@ function FiltersDrawer({ filterSettings }: { filterSettings?: FiltersProps }) {
           )}
           aria-describedby={undefined}
         >
+          <ShopifyInboxOverlayGuard />
           <div className="space-y-1">
             <div className="flex items-center justify-between gap-2 px-4">
               <Dialog.Title asChild className="py-2.5 font-bold">

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -6,6 +6,19 @@
 @import "./keyframes.css";
 @import "./utilities.css";
 
+html[data-shopify-inbox-hidden] #shopify-chat-dummy,
+html[data-shopify-inbox-hidden] #dummy-chat-button-iframe,
+html[data-shopify-inbox-hidden] #shopify-chat {
+  display: none !important;
+}
+
+/* Shopify's shadow CSS forces `:host { display: block !important; }`, so
+ * `display: none` from the light DOM cannot hide a standalone loaded host. */
+html[data-shopify-inbox-hidden] inbox-online-store-chat {
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
+
 @layer base {
   *,
   ::after,


### PR DESCRIPTION
## Summary

Closes Weaverse/pilot#155.

Hide the Shopify Inbox launcher and open chat panel while storefront overlays are visible, then restore the widget after all overlays close.

## Changes

- Add a reusable, reference-counted `hideShopifyInbox()` helper.
- Add `ShopifyInboxOverlayGuard` for Radix dialog content.
- Hide both the placeholder iframe and loaded Shopify Chat widget.
- Handle Shopify’s Shadow DOM `:host { display: block !important; }` rule.
- Apply the guard to:
  - Cart drawer and cart action dialogs
  - Mobile menu
  - Predictive search
  - Quick shop modal/drawer
  - Product media zoom
  - Newsletter popup/modal
  - Account modal
  - Review image modal
  - Collection filters drawer
- Document how to hide Inbox in future overlays.
- Preserve the existing Shopify Inbox loading behavior.

## Verification

- Verified that Shopify Chat hides when the cart drawer opens.
- Verified that it becomes visible again after the drawer closes.
- Verified nested/overlapping overlays are handled through reference counting.
- Scoped Biome checks pass.
- Production build passes.