### PR TITLE
Export component availability types from Hydrogen

### DIFF
--- a/.specs/2026-07-23--function-based-component-availability/work-logs.md
+++ b/.specs/2026-07-23--function-based-component-availability/work-logs.md
@@ -7,3 +7,4 @@
 - Updated strict schema helpers, `SchemaBuilder`, Hydrogen options typing, tests, and the schema package README.
 - Verified 11 focused tests, 38 schema tests, schema/Hydrogen builds, Biome, and monorepo typecheck.
 - Left package versions and lockfile unchanged pending explicit release approval. Hydrogen's exact schema dependency must be updated after the independent schema release.
+- After publishing 5.17.0, verified the packed Hydrogen declaration and found the named availability types were not re-exported. Added explicit canonical imports/re-exports and updated `CreateHydrogenSchemaOptions` to consume them before a patch release.

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -20,11 +20,14 @@ import type {
 import type {
   // Enhanced type exports from schema package
   BasicInput,
+  ComponentAvailabilityContext,
+  ComponentGroup,
   HeadingInput,
   InputType,
   InspectorGroup,
   PageSEOData,
   PageType,
+  Resolvable,
   ComponentPresets as SchemaComponentPresets,
   SchemaType,
   SchemaValidationIssue,
@@ -45,11 +48,14 @@ export type { CachingStrategy } from '@shopify/hydrogen'
 export type {
   // Enhanced type exports
   BasicInput,
+  ComponentAvailabilityContext,
+  ComponentGroup,
   HeadingInput,
   InputType,
   InspectorGroup,
   PageType,
   PositionInputValue,
+  Resolvable,
   SchemaValidationIssue,
   SchemaValidationResult,
   WeaverseImage,
@@ -595,17 +601,7 @@ export type CreateHydrogenSchemaOptions = {
     pages?: PageType[]
     groups?: ('*' | 'header' | 'footer' | 'body')[]
   }
-  enabled?:
-    | boolean
-    | ((context: {
-        page: {
-          id: string
-          type: PageType
-          handle: string
-          locale: string
-        }
-        group: 'body' | 'header' | 'footer'
-      }) => boolean)
+  enabled?: Resolvable<boolean, ComponentAvailabilityContext>
   presets?: {
     children?: SchemaComponentPresets[]
     [key: string]: any


### PR DESCRIPTION
## Summary

- explicitly re-export component availability types from the Hydrogen declaration bundle
- use canonical schema types for `CreateHydrogenSchemaOptions.enabled`
- ensure `ComponentAvailabilityContext`, `ComponentGroup`, and `Resolvable` are available to Hydrogen consumers

## Validation

- full Biome, typecheck, and test suite
- Hydrogen build
- inspected `dist/index.d.ts` for named exports and canonical enabled type
