### PR TITLE
Deprecate enabledOn component availability

### DIFF
--- a/.specs/2026-07-23--function-based-component-availability/work-logs.md
+++ b/.specs/2026-07-23--function-based-component-availability/work-logs.md
@@ -8,3 +8,4 @@
 - Verified 11 focused tests, 38 schema tests, schema/Hydrogen builds, Biome, and monorepo typecheck.
 - Left package versions and lockfile unchanged pending explicit release approval. Hydrogen's exact schema dependency must be updated after the independent schema release.
 - After publishing 5.17.0, verified the packed Hydrogen declaration and found the named availability types were not re-exported. Added explicit canonical imports/re-exports and updated `CreateHydrogenSchemaOptions` to consume them before a patch release.
+- Deprecated `enabledOn` in favor of `enabled` through a documented compatibility overlay on the existing Zod-inferred `SchemaType`. A broader explicit-interface/declaration-map rollout was deferred because changing required-field behavior in non-strict consumers is not patch-safe.

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -588,15 +588,14 @@ export function isValidHydrogenSchema(
   return isValidSchema(schema)
 }
 
-/**
- * Type-safe helper to create component schemas with validation
- */
+/** Type-safe component schema authoring options. */
 export type CreateHydrogenSchemaOptions = {
   title: string
   type: string
   limit?: number
   settings?: InspectorGroup[]
   childTypes?: string[]
+  /** @deprecated Use `enabled` instead. */
   enabledOn?: {
     pages?: PageType[]
     groups?: ('*' | 'header' | 'footer' | 'body')[]

--- a/packages/schema/AGENTS.md
+++ b/packages/schema/AGENTS.md
@@ -58,7 +58,7 @@ let schema = schemaBuilder()
     ]),
   ]))
   .childTypes(['hero-slide'])
-  .enabledOn({ pages: ['PRODUCT'], groups: ['body'] })
+  .enabled(({ page, group }) => page.type === 'PRODUCT' && group === 'body')
   .build()
 
 // Quick input helpers
@@ -110,6 +110,7 @@ devTools.generateTypeInterface(schema) // TypeScript interface string
 ## Anti-Patterns
 
 - **Don't** use `inspector` → use `settings`
+- **Don't** use `enabledOn` → use `enabled` with page/group checks
 - **Don't** import from `zod` → use `zod/v4` for v4 features
 - **Don't** mutate schema objects after creation
 - **Don't** skip validation in production — use `validateSchema()` or `isValidSchema()`

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -62,6 +62,7 @@ export type ElementSchema = {
   inspector?: InspectorGroup[] // @deprecated Use settings instead
   settings?: InspectorGroup[]
   childTypes?: string[]
+  /** @deprecated Use enabled instead. */
   enabledOn?: {
     pages?: ('*' | PageType)[]
     groups?: ('*' | 'header' | 'footer' | 'body')[]
@@ -155,19 +156,35 @@ import { createSchema } from '@weaverse/schema'
 const schema = createSchema({
   title: 'Freebies',
   type: 'freebies',
-  enabledOn: {
-    pages: ['CUSTOM'],
-  },
   enabled: ({ page, group }) =>
-    page.handle === 'freebies/essential' && group === 'body',
+    page.type === 'CUSTOM' &&
+    page.handle === 'freebies/essential' &&
+    group === 'body',
 })
 ```
 
 `enabled` accepts a boolean or a synchronous callback. The callback receives
 `page` (`id`, `type`, `handle`, and `locale`) and `group` (`body`, `header`, or
-`footer`). When both `enabledOn` and `enabled` are set, both rules must pass.
-The SDK preserves callbacks without executing them; the Weaverse preview bridge
+`footer`). The SDK preserves callbacks without executing them; the Weaverse preview bridge
 evaluates them against its current page context.
+
+`enabledOn` is deprecated. Move its page and group checks into `enabled`:
+
+```typescript
+// Before
+const legacy = createSchema({
+  title: 'Product recommendations',
+  type: 'product-recommendations',
+  enabledOn: { pages: ['PRODUCT'], groups: ['body'] },
+})
+
+// After
+const current = createSchema({
+  title: 'Product recommendations',
+  type: 'product-recommendations',
+  enabled: ({ page, group }) => page.type === 'PRODUCT' && group === 'body',
+})
+```
 
 ### Schema Builder Pattern
 
@@ -196,11 +213,9 @@ const schema = schemaBuilder()
       inputHelpers.switch('showPrice', 'Show Price', true)
     ])
   )
-  .enabledOn({
-    pages: ['PRODUCT', 'COLLECTION'],
-    groups: ['body']
-  })
-  .enabled(({ group }) => group === 'body')
+  .enabled(({ page, group }) =>
+    ['PRODUCT', 'COLLECTION'].includes(page.type) && group === 'body'
+  )
   .build()
 ```
 
@@ -360,13 +375,13 @@ All types are inferred from Zod schemas, ensuring:
 
 ```bash
 # Install dependencies
-npm install
+pnpm install
 
 # Build the package
-npm run build
+pnpm run build
 
 # Type check
-npm run typecheck
+pnpm run typecheck
 ```
 
 ## Type Safety and Required Fields
@@ -377,19 +392,15 @@ The `title` and `type` fields are **required** at runtime (enforced by Zod valid
 
 #### Runtime Validation
 
-The schema always enforces required fields at runtime:
+`createSchema()` returns the original schema and reports validation issues in development. Use `parseSchema()` when invalid input must throw:
 
 ```typescript
-// ✅ This works
-const validSchema = createSchema({
+const schema = createSchema({
   title: 'My Component',
   type: 'my-component',
 })
 
-// ❌ This throws a ZodError at runtime
-const invalidSchema = createSchema({
-  // Missing required fields
-})
+const validatedSchema = parseSchema(unknownSchema) // Throws on invalid input
 ```
 
 #### TypeScript Type Safety
@@ -450,7 +461,7 @@ const schema = createSchema({
 
 ### Functions
 
-- `createSchema(schema: SchemaType)` - Validates and returns a schema
+- `createSchema(schema: SchemaType)` - Returns a schema and schedules development-only validation
 - `createSchemaTypeSafe(schema: SchemaTypeStrict)` - Type-safe schema creation with enforced required fields
 
 ### Schemas
@@ -467,6 +478,7 @@ The schema package is now the source of truth for all component schema types. Th
 ### Deprecated Fields
 
 - `inspector` is deprecated in favor of `settings` (both have the same structure)
+- `enabledOn` is deprecated in favor of `enabled`; move page and group checks into the callback
 
 ## Type System Architecture
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,12 +1,8 @@
 import type {
   BasicInput,
-  ComponentAvailabilityContext,
-  ComponentPresets,
   HeadingInput,
   InspectorGroup,
-  PageType,
   RangeInputConfigs,
-  Resolvable,
   SchemaType,
   SchemaValidationIssue,
 } from './validation'
@@ -22,30 +18,10 @@ export type {
   TwitterCardType,
 } from './page-seo'
 
-/**
- * Type-safe schema type with enforced required fields.
- * Use this when you need strict TypeScript checking for required fields.
- *
- * Note: The inferred SchemaType may show 'title' and 'type' as optional
- * in TypeScript when strict mode is disabled, but they are required at runtime.
- * This type explicitly enforces them as required.
- */
-export type SchemaTypeStrict = {
+/** Schema type with required title and type fields in non-strict projects. */
+export type SchemaTypeStrict = SchemaType & {
   title: string
   type: string
-  limit?: number
-  inspector?: InspectorGroup[]
-  settings?: InspectorGroup[]
-  childTypes?: string[]
-  enabledOn?: {
-    pages?: PageType[]
-    groups?: ('*' | 'header' | 'footer' | 'body')[]
-  }
-  enabled?: Resolvable<boolean, ComponentAvailabilityContext>
-  presets?: {
-    children?: ComponentPresets[]
-    [key: string]: any
-  }
 }
 
 function reportSchemaIssues(issues: readonly SchemaValidationIssue[]): void {
@@ -93,23 +69,7 @@ export function createSchema(schema: SchemaType): SchemaType {
  * when the consumer's TypeScript `strict` mode is disabled. Validation is
  * dev-only, exactly as in {@link createSchema}.
  */
-export function createSchemaTypeSafe(schema: {
-  title: string
-  type: string
-  limit?: number
-  inspector?: InspectorGroup[]
-  settings?: InspectorGroup[]
-  childTypes?: string[]
-  enabledOn?: {
-    pages?: PageType[]
-    groups?: ('*' | 'header' | 'footer' | 'body')[]
-  }
-  enabled?: Resolvable<boolean, ComponentAvailabilityContext>
-  presets?: {
-    children?: ComponentPresets[]
-    [key: string]: any
-  }
-}): SchemaType {
+export function createSchemaTypeSafe(schema: SchemaTypeStrict): SchemaType {
   if (process.env.NODE_ENV !== 'production') {
     void import('./validation')
       .then(({ validateSchema }) => {
@@ -174,6 +134,7 @@ export class SchemaBuilder {
     return this
   }
 
+  /** @deprecated Use {@link enabled} instead. */
   enabledOn(enabledOn: SchemaType['enabledOn']): SchemaBuilder {
     this.schema.enabledOn = enabledOn
     return this

--- a/packages/schema/src/validation.ts
+++ b/packages/schema/src/validation.ts
@@ -189,11 +189,17 @@ export type Resolvable<T, Context> = T | ((context: Context) => T)
 export type ComponentGroup = 'body' | 'header' | 'footer'
 
 export interface ComponentAvailabilityContext {
+  /** Placement group currently being evaluated. */
   group: ComponentGroup
+  /** Active storefront page information. */
   page: {
+    /** Weaverse page identifier. */
     id: string
+    /** Weaverse page type. */
     type: PageType
+    /** Route handle, without a leading slash. */
     handle: string
+    /** Active storefront locale. */
     locale: string
   }
 }
@@ -303,7 +309,18 @@ export const typeSchema = z
   )
 
 // Type exports - inferred from Zod schemas
-export type SchemaType = z.infer<typeof ElementSchema>
+
+type InferredSchemaType = z.infer<typeof ElementSchema>
+
+export type SchemaType = Omit<InferredSchemaType, 'enabledOn'> & {
+  /**
+   * @deprecated Use `enabled` for both static and context-aware availability
+   * rules. Existing schemas remain supported, and both rules must pass when
+   * both properties are present.
+   */
+  enabledOn?: InferredSchemaType['enabledOn']
+}
+
 export type InputType = z.infer<typeof inputTypeSchema>
 export type BasicInput = z.infer<typeof BasicInputSchema>
 export type HeadingInput = z.infer<typeof HeadingInputSchema>


### PR DESCRIPTION
## Summary

- mark `enabledOn` deprecated in schema, Hydrogen options, and SchemaBuilder declarations
- document migration to equivalent `enabled` page/group checks
- preserve the existing Zod-inferred `SchemaType` behavior through a compatibility overlay
- keep strict/non-strict consumer behavior unchanged for patch safety

## Validation

- full Biome, typecheck, test, and build suites
- inspected generated schema and Hydrogen declarations for `@deprecated`
