### PR TITLE
Publish declaration maps for SDK sources

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+api-reports/*.api.md whitespace=cr-at-eol

--- a/.specs/2026-07-23--public-sdk-navigation/plan.md
+++ b/.specs/2026-07-23--public-sdk-navigation/plan.md
@@ -22,12 +22,13 @@
 - Packed artifacts, not source imports, prove the package interface.
 - Existing permissive schema authoring behavior has compatibility fixtures.
 
-## Phase 2 — Restore authored-source navigation
+## Phase 2 — Restore authored-source navigation (in progress)
 
 1. Prototype source-preserving declaration output on `@weaverse/schema`.
-2. Emit declaration maps and include every mapped source in the tarball.
-3. Verify all map targets after packing.
-4. Roll the proven configuration through Core, React, Hydrogen, Experiments, and Next.
+   - Result: unbundled Zod inference changed strict/non-strict consumer behavior, so Schema remains bundled until Phase 3 introduces equivalent explicit contracts.
+2. Emit source-preserving declarations and declaration maps for Core, React, Hydrogen, Experiments, and Next.
+3. Include every mapped source in each tarball and verify map targets after packing.
+4. Complete Schema navigation after its compatibility boundary is removed.
 
 ### Exit criteria
 

--- a/.specs/2026-07-23--public-sdk-navigation/work-logs.md
+++ b/.specs/2026-07-23--public-sdk-navigation/work-logs.md
@@ -17,3 +17,15 @@
 - Added distinct strict/loose compatibility fixtures and a `skipLibCheck: false` declaration pass for Core, React, Schema, and Experiments.
 - Corrected the root Node engine to `>=22.13`, matching pnpm 11.1.2.
 - Accepted bounded Phase 1 limitations: the Next browser entry is statically inventoried and CJS-executed but not directly ESM-executed under Node, and API Extractor currently analyzes with bundled TypeScript 5.9 while the repo uses TypeScript 6.
+
+## 2026-07-23 — @paul (Phase 2)
+
+- Added a source-preserving declaration build that emits `.d.ts` and `.d.ts.map` files, rewrites internal aliases, and copies authored declaration inputs with identity maps.
+- Published authored `src` files and mapped declarations for Core, React, Hydrogen, Experiments, and Next.
+- Added packed-tarball validation ensuring every declaration map resolves to an included source file inside the same package.
+- Preserved all public export counts and strict/non-strict compatibility in isolated packed consumers.
+- Prototyped the same output for Schema, but its exported `z.infer` aliases became consumer-compiler-dependent when unbundled. Kept Schema on its bundled declaration until Phase 3 can introduce proven-equivalent explicit contracts.
+- Verified a clean install/build, API report checks, and packed declaration-map checks.
+- Replaced internal source aliases with relative imports so TypeScript-generated maps remain byte/column faithful; ESM Experiments sources now author their required `.js` specifiers directly.
+- Added exact identity maps for authored `.d.ts` inputs using `@jridgewell/gen-mapping` and trace-based validation for every sampled position.
+- Added the declaration builder to Turbo's global cache inputs and added CJS consumer coverage alongside ESM checks.

--- a/api-reports/README.md
+++ b/api-reports/README.md
@@ -1,6 +1,6 @@
 # Public API Reports
 
-These files snapshot the built TypeScript interface for every published TypeScript package entrypoint. They are generated from `dist/*.d.ts` with API Extractor and must not be edited manually.
+These files snapshot the built TypeScript interface for every published TypeScript package entrypoint. They are generated from each package's configured declaration entry with API Extractor and must not be edited manually.
 
 ```sh
 pnpm run api:report   # build and accept intentional interface changes
@@ -8,4 +8,6 @@ pnpm run api:check    # build and verify reports are current
 pnpm run package:check # verify reports and packed strict/non-strict consumers
 ```
 
-Review report diffs as public package changes. `@weaverse/cli` and `@weaverse/biome` are published directly and do not expose TypeScript declaration entrypoints, so they have no API report.
+Review report diffs as public package changes. The package check also verifies that declaration maps resolve to authored sources included in each tarball. Schema remains on a bundled declaration until its Zod-inferred types can be made source-preserving without changing strict/non-strict compatibility.
+
+`@weaverse/cli` and `@weaverse/biome` are published directly and do not expose TypeScript declaration entrypoints, so they have no API report.

--- a/api-reports/core.api.md
+++ b/api-reports/core.api.md
@@ -4,8 +4,8 @@
 
 ```ts
 
-import { CSSProperties } from 'react';
-import { ForwardRefExoticComponent } from 'react';
+import type { CSSProperties } from 'react';
+import type { ForwardRefExoticComponent } from 'react';
 import { RefObject } from 'react';
 
 // @public (undocumented)

--- a/api-reports/experiments.react.api.md
+++ b/api-reports/experiments.react.api.md
@@ -4,8 +4,8 @@
 
 ```ts
 
-import * as react_jsx_runtime from 'react/jsx-runtime';
-import { ReactNode } from 'react';
+import { JSX } from 'react/jsx-runtime';
+import type { ReactNode } from 'react';
 
 // @public
 export function createExposureTracker(): ExposureTracker;
@@ -22,7 +22,7 @@ export function useExperiment(experimentId: string): Assignment | undefined;
 export function useExperiments(): Assignment[];
 
 // @public
-export function WeaverseExperiments(input: WeaverseExperimentsProps): react_jsx_runtime.JSX.Element;
+export function WeaverseExperiments(input: WeaverseExperimentsProps): JSX.Element;
 
 // @public (undocumented)
 export interface WeaverseExperimentsProps {

--- a/api-reports/experiments.server.api.md
+++ b/api-reports/experiments.server.api.md
@@ -13,7 +13,7 @@ export interface ExperimentsResult {
     setCookie?: string;
 }
 
-// @public
+// @public (undocumented)
 export interface ExperimentsServerConfig {
     cookieName?: string;
     experiments: Experiment[];

--- a/api-reports/hydrogen.api.md
+++ b/api-reports/hydrogen.api.md
@@ -4,52 +4,53 @@
 
 ```ts
 
-import { AppLoadContext } from '@shopify/remix-oxygen';
-import { BasicInput } from '@weaverse/schema';
+import type { AppLoadContext } from '@shopify/remix-oxygen';
+import type { BasicInput } from '@weaverse/schema';
 import { CachingStrategy } from '@shopify/hydrogen';
-import { ComponentAvailabilityContext } from '@weaverse/schema';
-import { ComponentGroup } from '@weaverse/schema';
-import { ComponentPresets } from '@weaverse/schema';
+import type { ComponentAvailabilityContext } from '@weaverse/schema';
+import type { ComponentGroup } from '@weaverse/schema';
+import type { ComponentPresets } from '@weaverse/schema';
 import { ComponentType } from 'react';
 import { createWithCache } from '@shopify/hydrogen';
-import { ElementData } from '@weaverse/react';
-import { ForwardRefExoticComponent } from 'react';
-import { HeadingInput } from '@weaverse/schema';
-import { HydrogenContext } from '@shopify/hydrogen';
-import { HydrogenEnv } from '@shopify/hydrogen';
-import { I18nBase } from '@shopify/hydrogen';
-import { InputType } from '@weaverse/schema';
-import { InspectorGroup } from '@weaverse/schema';
+import type { ElementData } from '@weaverse/react';
+import type { ForwardRefExoticComponent } from 'react';
+import type { HeadingInput } from '@weaverse/schema';
+import type { HydrogenContext } from '@shopify/hydrogen';
+import type { HydrogenEnv } from '@shopify/hydrogen';
+import type { I18nBase } from '@shopify/hydrogen';
+import type { InputType } from '@weaverse/schema';
+import type { InspectorGroup } from '@weaverse/schema';
 import { isBrowser } from '@weaverse/react';
 import { isIframe } from '@weaverse/react';
-import { JSX as JSX_2 } from 'react';
-import { LoaderFunctionArgs } from '@shopify/remix-oxygen';
-import { MetaDescriptor } from 'react-router';
-import { NavigateFunction } from 'react-router';
-import { PageSEOData } from '@weaverse/schema';
-import { PageType } from '@weaverse/schema';
-import { PositionInputValue } from '@weaverse/react';
-import * as React$1 from 'react';
-import * as react_jsx_runtime from 'react/jsx-runtime';
+import { JSX as JSX_2 } from 'react/jsx-runtime';
+import { JSX as JSX_3 } from 'react';
+import type { LoaderFunctionArgs } from '@shopify/remix-oxygen';
+import { MemoExoticComponent } from 'react';
+import type { MetaDescriptor } from 'react-router';
+import type { NavigateFunction } from 'react-router';
+import type { PageSEOData } from '@weaverse/schema';
+import type { PageType } from '@weaverse/schema';
+import type { PositionInputValue } from '@weaverse/react';
+import type * as React_2 from 'react';
 import { ReactNode } from 'react';
-import { Resolvable } from '@weaverse/schema';
-import { SchemaType } from '@weaverse/schema';
-import { SchemaValidationIssue } from '@weaverse/schema';
-import { SchemaValidationResult } from '@weaverse/schema';
-import { SelectedOptionInput } from '@shopify/hydrogen/storefront-api-types';
+import type { Resolvable } from '@weaverse/schema';
+import type { SchemaType } from '@weaverse/schema';
+import type { SchemaValidationIssue } from '@weaverse/schema';
+import type { SchemaValidationResult } from '@weaverse/schema';
+import type { SelectedOptionInput } from '@shopify/hydrogen/storefront-api-types';
 import { UIMatch } from 'react-router';
 import { useChildInstances } from '@weaverse/react';
 import { useItemInstance } from '@weaverse/react';
 import { useParentInstance } from '@weaverse/react';
 import { useWeaverse } from '@weaverse/react';
 import { Weaverse } from '@weaverse/react';
-import { WeaverseCoreParams } from '@weaverse/react';
-import { WeaverseElement } from '@weaverse/react';
-import { WeaverseImage } from '@weaverse/react';
+import type { WeaverseCoreParams } from '@weaverse/react';
+import type { WeaverseElement } from '@weaverse/react';
+import type { WeaverseImage } from '@weaverse/react';
 import { WeaverseItemStore } from '@weaverse/react';
-import { WeaverseProjectDataType } from '@weaverse/react';
-import { WeaverseResourcePickerData } from '@weaverse/react';
-import { WeaverseVideo } from '@weaverse/react';
+import type { WeaverseProjectDataType } from '@weaverse/react';
+import type { WeaverseResourcePickerData } from '@weaverse/react';
+import type { WeaverseVideo } from '@weaverse/react';
 
 export { BasicInput }
 
@@ -181,7 +182,7 @@ export { HeadingInput }
 
 // @public (undocumented)
 export type HydrogenComponent<T extends HydrogenComponentProps = any> = {
-    default: ForwardRefExoticComponent<T> | ((props: T) => React$1.JSX.Element);
+    default: ForwardRefExoticComponent<T> | ((props: T) => React_2.JSX.Element);
     schema: HydrogenComponentSchema;
     loader?: (args: ComponentLoaderArgs) => Promise<unknown>;
 };
@@ -212,7 +213,7 @@ export type HydrogenComponentPresets = ComponentPresets;
 // @public (undocumented)
 export interface HydrogenComponentProps<L = any> extends WeaverseElement {
     // (undocumented)
-    children?: React$1.JSX.Element[];
+    children?: React_2.JSX.Element[];
     // (undocumented)
     className?: string;
     // (undocumented)
@@ -224,7 +225,7 @@ export type HydrogenComponentSchema = SchemaType;
 
 // @public (undocumented)
 export type HydrogenElement = {
-    Component: ForwardRefExoticComponent<HydrogenComponentProps> | ((props: HydrogenComponentProps) => React$1.JSX.Element);
+    Component: ForwardRefExoticComponent<HydrogenComponentProps> | ((props: HydrogenComponentProps) => React_2.JSX.Element);
     type: string;
     schema?: HydrogenComponentSchema;
     loader?: (args: ComponentLoaderArgs) => Promise<unknown>;
@@ -467,7 +468,7 @@ export interface TranslationMapEntry {
 }
 
 // @public
-export function TranslationProvider(input: TranslationProviderProps): react_jsx_runtime.JSX.Element;
+export function TranslationProvider(input: TranslationProviderProps): JSX_2.Element;
 
 // @public (undocumented)
 export type TranslationProviderProps = {
@@ -691,13 +692,13 @@ export interface WeaverseHydrogenParams extends Omit<WeaverseCoreParams, 'ItemCo
 }
 
 // @public (undocumented)
-export const WeaverseHydrogenRoot: React$1.MemoExoticComponent<(input: {
-    components: HydrogenComponent[];
-    data?: WeaverseDataValue;
-    errorComponent?: React.FC<{
-        error: Error | unknown;
-    }>;
-}) => react_jsx_runtime.JSX.Element | null>;
+export const WeaverseHydrogenRoot: MemoExoticComponent<(input: {
+components: HydrogenComponent[];
+data?: WeaverseDataValue;
+errorComponent?: React.FC<{
+error: Error | unknown;
+}>;
+}) => JSX_2.Element | null>;
 
 // @public (undocumented)
 export type WeaverseI18n = I18nBase & {
@@ -781,7 +782,7 @@ export type WithCacheFetchResponse<T> = {
 };
 
 // @public
-export function withWeaverse(Component: ComponentType<any>, options?: WithWeaverseOptions): (props: JSX_2.IntrinsicAttributes) => react_jsx_runtime.JSX.Element;
+export function withWeaverse(Component: ComponentType<any>, options?: WithWeaverseOptions): (props: JSX_3.IntrinsicAttributes) => JSX_2.Element;
 
 // @public
 export type WithWeaverseOptions = {

--- a/api-reports/next.api.md
+++ b/api-reports/next.api.md
@@ -4,27 +4,27 @@
 
 ```ts
 
-import { ComponentType } from 'react';
-import { ElementData } from '@weaverse/react';
-import { ForwardRefExoticComponent } from 'react';
-import { InspectorGroup } from '@weaverse/schema';
+import type { ComponentType } from 'react';
+import type { ElementData } from '@weaverse/react';
+import type { ForwardRefExoticComponent } from 'react';
+import type { InspectorGroup } from '@weaverse/schema';
 import { isBrowser } from '@weaverse/react';
 import { isIframe } from '@weaverse/react';
-import { Metadata } from 'next';
-import { PageSEOData } from '@weaverse/schema';
+import { JSX } from 'react/jsx-runtime';
+import { MemoExoticComponent } from 'react';
+import type { Metadata } from 'next';
+import type { PageSEOData } from '@weaverse/schema';
 import { PageType } from '@weaverse/schema';
-import * as react from 'react';
-import * as react_jsx_runtime from 'react/jsx-runtime';
 import { ReactNode } from 'react';
-import { SchemaType } from '@weaverse/schema';
+import type { SchemaType } from '@weaverse/schema';
 import { useChildInstances } from '@weaverse/react';
 import { useItemInstance } from '@weaverse/react';
 import { useParentInstance } from '@weaverse/react';
 import { useWeaverse } from '@weaverse/react';
 import { Weaverse } from '@weaverse/react';
-import { WeaverseElement } from '@weaverse/react';
+import type { WeaverseElement } from '@weaverse/react';
 import { WeaverseItemStore } from '@weaverse/react';
-import { WeaverseResourcePickerData } from '@weaverse/react';
+import type { WeaverseResourcePickerData } from '@weaverse/react';
 
 // @public (undocumented)
 export function bindWeaverseNextStudioRuntime(runtime: WeaverseNextRuntime): boolean;
@@ -153,7 +153,7 @@ export type ThemeTextValue = TranslationValue;
 export type TranslateFunction = (key: string, variables?: Record<string, string | number>) => string;
 
 // @public
-export function TranslationProvider(input: TranslationProviderProps): react_jsx_runtime.JSX.Element;
+export function TranslationProvider(input: TranslationProviderProps): JSX.Element;
 
 // @public (undocumented)
 export interface TranslationProviderProps {
@@ -439,7 +439,7 @@ export interface WeaverseNextPageData {
 }
 
 // @public
-export function WeaverseNextProvider(props: WeaverseNextProviderProps): react_jsx_runtime.JSX.Element;
+export function WeaverseNextProvider(props: WeaverseNextProviderProps): JSX.Element;
 
 // @public (undocumented)
 export interface WeaverseNextProviderProps {
@@ -457,7 +457,7 @@ export interface WeaverseNextProviderProps {
 }
 
 // @public
-export const WeaverseNextRenderer: react.MemoExoticComponent<(props: WeaverseNextRendererProps) => react_jsx_runtime.JSX.Element | null>;
+export const WeaverseNextRenderer: MemoExoticComponent<(props: WeaverseNextRendererProps) => JSX.Element | null>;
 
 // @public (undocumented)
 export interface WeaverseNextRendererProps {
@@ -516,7 +516,7 @@ export interface WeaverseNextRootContextValue {
 }
 
 // @public
-export function WeaverseNextRootProvider(props: WeaverseNextRootProviderProps): react_jsx_runtime.JSX.Element;
+export function WeaverseNextRootProvider(props: WeaverseNextRootProviderProps): JSX.Element;
 
 // @public (undocumented)
 export interface WeaverseNextRootProviderProps {
@@ -653,7 +653,7 @@ export interface WeaverseNextStorefront {
 }
 
 // @public
-export function WeaverseNextStudio(props: WeaverseNextStudioProps): react_jsx_runtime.JSX.Element;
+export function WeaverseNextStudio(props: WeaverseNextStudioProps): JSX.Element;
 
 // @public
 export function WeaverseNextStudioBridge(props: WeaverseNextStudioBridgeProps): null;

--- a/api-reports/next.server.api.md
+++ b/api-reports/next.server.api.md
@@ -4,15 +4,15 @@
 
 ```ts
 
-import { ComponentType } from 'react';
-import { ForwardRefExoticComponent } from 'react';
-import { InspectorGroup } from '@weaverse/schema';
-import { Metadata } from 'next';
-import { PageSEOData } from '@weaverse/schema';
-import { PageType } from '@weaverse/schema';
-import { ReactNode } from 'react';
-import { SchemaType } from '@weaverse/schema';
-import { WeaverseElement } from '@weaverse/react';
+import type { ComponentType } from 'react';
+import type { ForwardRefExoticComponent } from 'react';
+import type { InspectorGroup } from '@weaverse/schema';
+import type { Metadata } from 'next';
+import type { PageSEOData } from '@weaverse/schema';
+import type { PageType } from '@weaverse/schema';
+import type { ReactNode } from 'react';
+import type { SchemaType } from '@weaverse/schema';
+import type { WeaverseElement } from '@weaverse/react';
 
 // @public
 export function createWeaverseNextRevalidateHandler(config: WeaverseNextRevalidateHandlerConfig): {

--- a/api-reports/react.api.md
+++ b/api-reports/react.api.md
@@ -4,12 +4,13 @@
 
 ```ts
 
-import { ElementCSS } from '@weaverse/core';
-import * as react from 'react';
-import react__default from 'react';
-import * as react_jsx_runtime from 'react/jsx-runtime';
-import { ReactElement } from 'react';
-import { ReactNode } from 'react';
+import { Context } from 'react';
+import type { ElementCSS } from '@weaverse/core';
+import { JSX } from 'react/jsx-runtime';
+import { Provider } from 'react';
+import { default as React_2 } from 'react';
+import type { ReactElement } from 'react';
+import type { ReactNode } from 'react';
 import { Weaverse } from '@weaverse/core';
 import { WeaverseItemStore } from '@weaverse/core';
 
@@ -40,10 +41,10 @@ export const useSafeExternalStore: (subscribe: any, getSnapshot: any, getServerS
 export function useWeaverse<T = Weaverse>(): T;
 
 // @public (undocumented)
-export let WeaverseContext: react.Context<Weaverse>;
+export let WeaverseContext: Context<Weaverse>;
 
 // @public (undocumented)
-export let WeaverseContextProvider: react.Provider<Weaverse>;
+export let WeaverseContextProvider: Provider<Weaverse>;
 
 // @public (undocumented)
 export interface WeaverseElementProps extends Partial<ReactElement> {
@@ -58,13 +59,13 @@ export interface WeaverseElementProps extends Partial<ReactElement> {
 }
 
 // @public (undocumented)
-export let WeaverseItemContext: react.Context<{
-    id: string;
-    parentId: string;
+export let WeaverseItemContext: Context<    {
+id: string;
+parentId: string;
 }>;
 
 // @public (undocumented)
-export const WeaverseRoot: react__default.MemoExoticComponent<(input: WeaverseRootPropsType) => react_jsx_runtime.JSX.Element | null>;
+export const WeaverseRoot: React_2.MemoExoticComponent<(input: WeaverseRootPropsType) => JSX.Element | null>;
 
 // @public (undocumented)
 export type WeaverseRootPropsType = {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.0",
+    "@jridgewell/gen-mapping": "0.3.13",
+    "@jridgewell/trace-mapping": "0.3.31",
     "@microsoft/api-extractor": "7.58.12",
     "@types/node": "25.5.2",
     "@types/react": "19.2.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "version": "5.17.1",
   "license": "MIT",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "module": "dist/index.mjs",
   "repository": {
     "url": "git+https://github.com/Weaverse/weaverse.git",
@@ -16,14 +16,15 @@
     "@weaverse:registry": "https://registry.npmjs.org"
   },
   "files": [
-    "dist/*"
+    "dist",
+    "src"
   ],
   "engines": {
     "node": ">=18"
   },
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/build-declarations.mjs",
     "clean": "rimraf dist",
     "typecheck": "tsc --noEmit",
     "test": "vp test --run"

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -8,7 +8,7 @@
   "sideEffects": false,
   "main": "dist/index.cjs",
   "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Weaverse/weaverse.git",
@@ -19,21 +19,22 @@
     "@weaverse:registry": "https://registry.npmjs.org"
   },
   "files": [
-    "dist/*"
+    "dist",
+    "src"
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./server": {
-      "types": "./dist/server.d.ts",
+      "types": "./dist/types/server.d.ts",
       "import": "./dist/server.js",
       "require": "./dist/server.cjs"
     },
     "./react": {
-      "types": "./dist/react.d.ts",
+      "types": "./dist/types/react.d.ts",
       "import": "./dist/react.js",
       "require": "./dist/react.cjs"
     }
@@ -43,7 +44,7 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/build-declarations.mjs",
     "clean": "rimraf dist",
     "test": "vp test --run",
     "typecheck": "tsc --noEmit"

--- a/packages/experiments/src/react.tsx
+++ b/packages/experiments/src/react.tsx
@@ -8,7 +8,7 @@
 
 import type { ReactNode } from 'react'
 import { createContext, useContext, useEffect, useRef } from 'react'
-import type { Assignment } from './index'
+import type { Assignment } from './index.js'
 
 export interface ExposureTracker {
   /**

--- a/packages/experiments/src/server.ts
+++ b/packages/experiments/src/server.ts
@@ -9,8 +9,8 @@
  * chosen variant to a Weaverse `projectId` for project-level A/B testing.
  */
 
-import type { Assignment, Experiment } from './index'
-import { resolveExperiments } from './index'
+import type { Assignment, Experiment } from './index.js'
+import { resolveExperiments } from './index.js'
 
 const DEFAULT_SEED_COOKIE = '_wv_vid'
 const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -5,7 +5,7 @@
   "version": "5.17.1",
   "license": "MIT",
   "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "typings": "dist/types/index.d.ts",
   "module": "dist/index.mjs",
   "publishConfig": {
     "access": "public",
@@ -16,14 +16,15 @@
     "directory": "packages/hydrogen"
   },
   "files": [
-    "dist/*"
+    "dist",
+    "src"
   ],
   "engines": {
     "node": ">=20"
   },
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/build-declarations.mjs",
     "clean": "rimraf dist",
     "test": "vp test --run",
     "typecheck": "tsc --noEmit"

--- a/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
+++ b/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
@@ -21,7 +21,7 @@ import {
   useMatches,
   useRouteLoaderData,
 } from 'react-router'
-import { defaultComponents } from '~/components'
+import { defaultComponents } from './components'
 import {
   type TranslateFunction,
   TranslationProvider,

--- a/packages/hydrogen/src/components/index.ts
+++ b/packages/hydrogen/src/components/index.ts
@@ -1,4 +1,4 @@
-import type { HydrogenComponent } from '~/types'
+import type { HydrogenComponent } from '../types'
 import MainComponent, { schema as mainSchema } from './main'
 
 export let defaultComponents: HydrogenComponent[] = [

--- a/packages/hydrogen/src/components/main.tsx
+++ b/packages/hydrogen/src/components/main.tsx
@@ -1,6 +1,6 @@
 import { createSchema, type SchemaType } from '@weaverse/schema'
 import type { HTMLAttributes } from 'react'
-import type { HydrogenComponentProps } from '~/types'
+import type { HydrogenComponentProps } from '../types'
 
 /*
   Main is the default Weaverse component that is used to render the main content.

--- a/packages/hydrogen/src/utils/use-studio.ts
+++ b/packages/hydrogen/src/utils/use-studio.ts
@@ -6,9 +6,9 @@ import {
   useNavigation,
   useRevalidator,
 } from 'react-router'
-import type { WeaverseHydrogen } from '~/index'
-import { hasWeaverseStudio } from '~/types'
 import { useTranslation } from '../hooks/translation-context'
+import type { WeaverseHydrogen } from '../index'
+import { hasWeaverseStudio } from '../types'
 import {
   observeNavigation,
   registerPixelInstance,

--- a/packages/hydrogen/src/utils/use-theme-settings-store.ts
+++ b/packages/hydrogen/src/utils/use-theme-settings-store.ts
@@ -5,7 +5,7 @@ import type {
   HydrogenThemeSchema,
   HydrogenThemeSettings,
   PublicEnv,
-} from '~/types'
+} from '../types'
 
 type WeaverseThemeData = {
   theme: HydrogenThemeSettings

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -5,16 +5,16 @@
   "version": "0.1.0-alpha.13",
   "license": "MIT",
   "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "typings": "dist/types/index.d.ts",
   "module": "dist/index.mjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./server": {
-      "types": "./dist/server.d.ts",
+      "types": "./dist/types/server.d.ts",
       "import": "./dist/server.mjs",
       "require": "./dist/server.js"
     },
@@ -29,14 +29,15 @@
     "directory": "packages/next"
   },
   "files": [
-    "dist/*"
+    "dist",
+    "src"
   ],
   "engines": {
     "node": ">=20"
   },
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/build-declarations.mjs",
     "clean": "rimraf dist",
     "test": "vp test --run --config vitest.config.ts",
     "typecheck": "tsc --noEmit"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,7 @@
   "version": "5.17.1",
   "license": "MIT",
   "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "typings": "dist/types/index.d.ts",
   "module": "dist/index.mjs",
   "repository": {
     "url": "git+https://github.com/Weaverse/weaverse.git",
@@ -16,14 +16,15 @@
     "@weaverse:registry": "https://registry.npmjs.org"
   },
   "files": [
-    "dist/*"
+    "dist",
+    "src"
   ],
   "engines": {
     "node": ">=18"
   },
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/build-declarations.mjs",
     "clean": "rimraf dist",
     "test": "vp test --run",
     "typecheck": "tsc --noEmit"

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -1,6 +1,6 @@
 import { Weaverse, type WeaverseItemStore } from '@weaverse/core'
 import { useContext } from 'react'
-import { WeaverseContext, WeaverseItemContext } from '~/context'
+import { WeaverseContext, WeaverseItemContext } from './context'
 
 // Re-export the data connector utilities
 export {

--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -1,8 +1,8 @@
 import type { Weaverse } from '@weaverse/core'
 import clsx from 'clsx'
 import React, { memo, useEffect, useMemo, useRef } from 'react'
-import { useItemInstance, useWeaverse } from '~/hooks'
 import { WeaverseContextProvider, WeaverseItemContext } from './context'
+import { useItemInstance, useWeaverse } from './hooks'
 import type { ItemComponentProps, WeaverseRootPropsType } from './types'
 import { replaceContentDataConnectorsDeep } from './utils/data-connector'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,12 @@ importers:
       '@biomejs/biome':
         specifier: 2.5.0
         version: 2.5.0
+      '@jridgewell/gen-mapping':
+        specifier: 0.3.13
+        version: 0.3.13
+      '@jridgewell/trace-mapping':
+        specifier: 0.3.31
+        version: 0.3.31
       '@microsoft/api-extractor':
         specifier: 7.58.12
         version: 7.58.12(@types/node@25.5.2)

--- a/scripts/build-declarations.mjs
+++ b/scripts/build-declarations.mjs
@@ -1,0 +1,110 @@
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { basename, dirname, join, relative, resolve, sep } from 'node:path'
+import { addSegment, GenMapping, toEncodedMap } from '@jridgewell/gen-mapping'
+import ts from 'typescript'
+
+const DECLARATION_SUFFIX = /\.d\.ts$/
+const BUNDLED_DECLARATION = /\.d\.(?:ts|mts|cts)(?:\.map)?$/
+let packageDir = process.cwd()
+let sourceDir = join(packageDir, 'src')
+let outputDir = join(packageDir, 'dist', 'types')
+let configPath = join(packageDir, 'tsconfig.json')
+function walk(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    let path = join(directory, entry.name)
+    return entry.isDirectory() ? walk(path) : [path]
+  })
+}
+
+function createIdentityMap(source, sourcePath, outputFile) {
+  let map = new GenMapping({ file: basename(outputFile), sourceRoot: '' })
+  for (let [lineIndex, line] of source.split('\n').entries()) {
+    for (let column = 0; column <= line.length; column += 1) {
+      addSegment(map, lineIndex, column, sourcePath, lineIndex, column)
+    }
+  }
+  return toEncodedMap(map)
+}
+
+function removeBundledDeclarations() {
+  let outputPrefix = `${resolve(outputDir)}${sep}`
+  for (let file of walk(join(packageDir, 'dist'))) {
+    if (
+      !resolve(file).startsWith(outputPrefix) &&
+      BUNDLED_DECLARATION.test(file)
+    ) {
+      unlinkSync(file)
+    }
+  }
+}
+
+function copyAuthoredDeclarations() {
+  for (let sourceFile of walk(sourceDir).filter((file) =>
+    DECLARATION_SUFFIX.test(file)
+  )) {
+    let outputFile = join(outputDir, relative(sourceDir, sourceFile))
+    let mapFile = `${outputFile}.map`
+    let source = readFileSync(sourceFile, 'utf8')
+    let sourcePath = relative(dirname(outputFile), sourceFile)
+      .split(sep)
+      .join('/')
+    let map = createIdentityMap(source, sourcePath, outputFile)
+
+    mkdirSync(dirname(outputFile), { recursive: true })
+    writeFileSync(
+      outputFile,
+      `${source}\n//# sourceMappingURL=${map.file}.map\n`
+    )
+    writeFileSync(mapFile, JSON.stringify(map))
+  }
+}
+
+let formatHost = {
+  getCanonicalFileName: (file) => file,
+  getCurrentDirectory: () => packageDir,
+  getNewLine: () => '\n',
+}
+let config = ts.readConfigFile(configPath, ts.sys.readFile)
+if (config.error) {
+  console.error(ts.formatDiagnostic(config.error, formatHost))
+  process.exit(1)
+}
+
+let parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, packageDir, {
+  noEmit: false,
+  emitDeclarationOnly: true,
+  declaration: true,
+  declarationMap: true,
+  rootDir: sourceDir,
+  outDir: outputDir,
+  incremental: false,
+  composite: false,
+})
+parsed.options.paths = {}
+let sourcePrefix = `${resolve(sourceDir)}${sep}`
+let rootNames = parsed.fileNames.filter(
+  (file) => file === resolve(sourceDir) || file.startsWith(sourcePrefix)
+)
+rmSync(outputDir, { recursive: true, force: true })
+let program = ts.createProgram({ rootNames, options: parsed.options })
+let emitResult = program.emit()
+let diagnostics = ts
+  .getPreEmitDiagnostics(program)
+  .concat(emitResult.diagnostics)
+
+if (diagnostics.length > 0) {
+  console.error(
+    ts.formatDiagnosticsWithColorAndContext(diagnostics, formatHost)
+  )
+  process.exit(1)
+}
+
+copyAuthoredDeclarations()
+removeBundledDeclarations()

--- a/scripts/check-packed-packages.mjs
+++ b/scripts/check-packed-packages.mjs
@@ -3,13 +3,15 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping'
 import ts from 'typescript'
 import {
   collectPublishedFiles,
@@ -23,6 +25,8 @@ let PNPM = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const RUNTIME_JSON_BLOCK = /```json\n([\s\S]*?)\n```/
 // Next's browser entry imports next/navigation, which is resolved by its bundler.
 const NODE_ESM_EXCLUSIONS = new Set(['@weaverse/next'])
+// Schema's Zod-inferred types change consumer strictness when emitted unbundled.
+const DECLARATION_MAP_EXCLUSIONS = new Set(['@weaverse/schema'])
 let publishedPackages = getPublishedPackages(ROOT_DIR)
 let typeEntrypoints = publishedPackages.flatMap((publishedPackage) =>
   publishedPackage.entrypoints
@@ -31,6 +35,13 @@ let typeEntrypoints = publishedPackages.flatMap((publishedPackage) =>
 )
 let scratchDir = mkdtempSync(join(tmpdir(), 'weaverse-packed-packages-'))
 let consumerDir = join(scratchDir, 'consumer')
+
+function walk(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    let path = join(directory, entry.name)
+    return entry.isDirectory() ? walk(path) : [path]
+  })
+}
 
 function run(command, args, options = {}) {
   let result = spawnSync(command, args, {
@@ -45,6 +56,25 @@ function run(command, args, options = {}) {
   }
 
   return result.stdout.trim()
+}
+
+function verifyIdentityMap(declarationFile, declarationMap, sourceFile) {
+  let traceMap = new TraceMap(declarationMap)
+  let lines = readFileSync(sourceFile, 'utf8').split('\n')
+
+  for (let [lineIndex, line] of lines.entries()) {
+    for (let column of new Set([0, Math.floor(line.length / 2), line.length])) {
+      let position = originalPositionFor(traceMap, {
+        line: lineIndex + 1,
+        column,
+      })
+      if (position.line !== lineIndex + 1 || position.column !== column) {
+        throw new Error(
+          `Declaration map is not identity-preserving at ${declarationFile}:${lineIndex + 1}:${column}`
+        )
+      }
+    }
+  }
 }
 
 function normalizeEntry(entryFile) {
@@ -148,6 +178,49 @@ try {
         )
       }
     }
+
+    let declarationFolders = DECLARATION_MAP_EXCLUSIONS.has(packageJson.name)
+      ? new Set()
+      : new Set(
+          publishedPackage.entrypoints
+            .filter((entrypoint) => entrypoint.types)
+            .map((entrypoint) =>
+              dirname(join(packedFolder, normalizeEntry(entrypoint.types)))
+            )
+        )
+    let declarationFiles = [...declarationFolders].flatMap((folder) =>
+      walk(folder).filter((file) => file.endsWith('.d.ts'))
+    )
+    let packedPrefix = `${resolve(packedFolder)}${sep}`
+
+    for (let declarationFile of declarationFiles) {
+      let mapFile = `${declarationFile}.map`
+      if (!existsSync(mapFile)) {
+        throw new Error(`${packageJson.name} is missing ${mapFile}`)
+      }
+
+      let declarationMap = JSON.parse(readFileSync(mapFile, 'utf8'))
+      for (let source of declarationMap.sources) {
+        let target = resolve(
+          dirname(mapFile),
+          declarationMap.sourceRoot ?? '',
+          source
+        )
+        if (!(target.startsWith(packedPrefix) && existsSync(target))) {
+          throw new Error(
+            `${packageJson.name} declaration map points outside its tarball: ${source}`
+          )
+        }
+        if (!target.includes(`${sep}src${sep}`)) {
+          throw new Error(
+            `${packageJson.name} declaration map does not target authored source: ${source}`
+          )
+        }
+        if (target.endsWith('.d.ts')) {
+          verifyIdentityMap(declarationFile, declarationMap, target)
+        }
+      }
+    }
   }
 
   for (let packageName of ['@weaverse/hydrogen', '@weaverse/schema']) {
@@ -156,14 +229,15 @@ try {
     )
     let declarationFiles = publishedPackage.entrypoints
       .filter((entrypoint) => entrypoint.types)
-      .map((entrypoint) =>
-        join(
+      .flatMap((entrypoint) => {
+        let entryFile = join(
           consumerDir,
           'node_modules',
           ...packageName.split('/'),
           normalizeEntry(entrypoint.types)
         )
-      )
+        return walk(dirname(entryFile)).filter((file) => file.endsWith('.d.ts'))
+      })
 
     if (!declarationFiles.some(hasDeprecatedEnabledOnProperty)) {
       throw new Error(
@@ -308,6 +382,29 @@ void [modules, componentSchema, hydrogenEnabled]
 `
   )
   writeFileSync(
+    join(consumerDir, 'consumer.cts'),
+    `import { Weaverse } from '@weaverse/core'
+import { assignVariant } from '@weaverse/experiments'
+import { createExposureTracker } from '@weaverse/experiments/react'
+import { getExperiments } from '@weaverse/experiments/server'
+import { WeaverseClient } from '@weaverse/hydrogen'
+import { createWeaverseNextClient } from '@weaverse/next'
+import { getWeaverseNextConfigs } from '@weaverse/next/server'
+import { WeaverseRoot } from '@weaverse/react'
+
+void [
+  Weaverse,
+  assignVariant,
+  createExposureTracker,
+  getExperiments,
+  WeaverseClient,
+  createWeaverseNextClient,
+  getWeaverseNextConfigs,
+  WeaverseRoot,
+]
+`
+  )
+  writeFileSync(
     join(consumerDir, 'strict.ts'),
     `import type { SchemaType } from '@weaverse/schema'
 
@@ -343,7 +440,11 @@ void legacyLooseSchema
             skipLibCheck: true,
             jsx: 'react-jsx',
           },
-          files: ['index.ts', strict ? 'strict.ts' : 'loose.ts'],
+          files: [
+            'index.ts',
+            'consumer.cts',
+            strict ? 'strict.ts' : 'loose.ts',
+          ],
         },
         null,
         2

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turborepo.org/schema.json",
+  "globalDependencies": ["scripts/build-declarations.mjs"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

Phase 2 of #500 restores authored-source navigation for five TypeScript packages:

- emit source-preserving declarations and declaration maps for Core, React, Hydrogen, Experiments, and Next
- publish the mapped `src` files in each tarball
- remove obsolete bundled declarations after each build
- validate every packed map target and authored `.d.ts` identity mapping
- cover ESM and CJS package consumers under strict and loose TypeScript modes
- include the shared declaration builder in Turbo's global cache hash

## Schema compatibility boundary

`@weaverse/schema` intentionally remains on its bundled declaration. The prototype exposed `z.infer` aliases to the consumer compiler and changed strict/non-strict behavior. Schema navigation will follow after Phase 3 introduces proven-equivalent explicit contracts.

## Validation

- clean install and forced build
- `pnpm run biome`
- `pnpm run typecheck`
- `pnpm run test` (481 passed, 1 skipped)
- `pnpm run package:check`
- packed map targets remain inside their tarballs and resolve to included authored sources
- exhaustive identity-map trace for the authored Core declaration
- API export counts unchanged
- independent review approved

This advances but does not close #500.
