### PR TITLE
Document schema public contracts

### DIFF
--- a/.specs/2026-07-23--public-sdk-navigation/plan.md
+++ b/.specs/2026-07-23--public-sdk-navigation/plan.md
@@ -22,22 +22,22 @@
 - Packed artifacts, not source imports, prove the package interface.
 - Existing permissive schema authoring behavior has compatibility fixtures.
 
-## Phase 2 — Restore authored-source navigation (in progress)
+## Phase 2 — Restore authored-source navigation (completed)
 
 1. Prototype source-preserving declaration output on `@weaverse/schema`.
-   - Result: unbundled Zod inference changed strict/non-strict consumer behavior, so Schema remains bundled until Phase 3 introduces equivalent explicit contracts.
-2. Emit source-preserving declarations and declaration maps for Core, React, Hydrogen, Experiments, and Next.
+   - Initial result: unbundled Zod inference changed strict/non-strict consumer behavior.
+   - Resolution: Phase 3 explicit contracts removed that compatibility boundary.
+2. Emit source-preserving declarations and declaration maps for Core, React, Hydrogen, Schema, Experiments, and Next.
 3. Include every mapped source in each tarball and verify map targets after packing.
-4. Complete Schema navigation after its compatibility boundary is removed.
 
 ### Exit criteria
 
 - Cmd/Ctrl+click from a packed consumer resolves to an included authored declaration/source file.
 - No package depends on missing declaration-map targets.
 
-## Phase 3 — Document the public interface
+## Phase 3 — Document the public interface (in progress)
 
-1. Add explicit documented contracts alongside inferred types, beginning with schema authoring types.
+1. Add explicit documented contracts alongside inferred types, beginning with schema authoring types. (Schema completed.)
 2. Prove bidirectional assignability against `z.input` and `z.output` where relevant.
 3. Add JSDoc to public functions, classes, methods, options, callbacks, and object properties.
 4. Preserve `@deprecated` tags and direct migration guidance in emitted declarations.
@@ -50,7 +50,7 @@
 
 ## Phase 4 — Enforcement and rollout
 
-1. Add CI checks for undocumented public declarations and broken map targets.
+1. Add CI checks for undocumented public declarations and broken map targets. (Schema documentation enforcement enabled.)
 2. Review API reports for every active TypeScript package.
 3. Build, typecheck, test, and inspect packed tarballs.
 4. Release packages in dependency order.

--- a/.specs/2026-07-23--public-sdk-navigation/work-logs.md
+++ b/.specs/2026-07-23--public-sdk-navigation/work-logs.md
@@ -29,3 +29,14 @@
 - Replaced internal source aliases with relative imports so TypeScript-generated maps remain byte/column faithful; ESM Experiments sources now author their required `.js` specifiers directly.
 - Added exact identity maps for authored `.d.ts` inputs using `@jridgewell/gen-mapping` and trace-based validation for every sampled position.
 - Added the declaration builder to Turbo's global cache inputs and added CJS consumer coverage alongside ESM checks.
+
+## 2026-07-23 — @paul (Phase 3: Schema)
+
+- Replaced Zod-inferred public authoring aliases with explicit interfaces and unions matching the existing output contract.
+- Added bidirectional assignability checks between every explicit schema contract and its `z.output` type.
+- Enabled Schema's source-preserving declarations and declaration maps after strict/loose packed consumers proved compatibility.
+- Added hover documentation for every public Schema symbol and property, including direct migration guidance on deprecated APIs.
+- Reduced Schema's API report from 55 undocumented markers to zero and enabled `ae-undocumented` as a CI error for the package.
+- Preserved the legacy permissive recursive preset contract (`children?: any[]`) with a concrete compile-time fixture.
+- Replaced anonymous validation and registry result objects with named, documented public interfaces.
+- Strengthened packed deprecation checks to require migration guidance for `enabledOn`, `inspector`, and `SchemaBuilder.enabledOn`.

--- a/api-reports/README.md
+++ b/api-reports/README.md
@@ -8,6 +8,6 @@ pnpm run api:check    # build and verify reports are current
 pnpm run package:check # verify reports and packed strict/non-strict consumers
 ```
 
-Review report diffs as public package changes. The package check also verifies that declaration maps resolve to authored sources included in each tarball. Schema remains on a bundled declaration until its Zod-inferred types can be made source-preserving without changing strict/non-strict compatibility.
+Review report diffs as public package changes. The package check also verifies that declaration maps resolve to authored sources included in each tarball. Schema uses explicit, Zod-aligned public contracts and enforces complete public documentation in CI; the remaining packages will adopt documentation enforcement incrementally.
 
 `@weaverse/cli` and `@weaverse/biome` are published directly and do not expose TypeScript declaration entrypoints, so they have no API report.

--- a/api-reports/schema.api.md
+++ b/api-reports/schema.api.md
@@ -7,74 +7,35 @@
 import { z } from 'zod/v4';
 
 // @public
-export function analyzeComponentRegistry(components: Record<string, any>): {
-    summary: {
-        total: number;
-        valid: number;
-        invalid: number;
-        types: string[];
-        duplicateTypes: string[];
-    };
-    details: Array<{
-        name: string;
-        type?: string;
-        title?: string;
-        valid: boolean;
-        error?: string;
-        settingsCount?: number;
-        hasPresets?: boolean;
-    }>;
-};
+export function analyzeComponentRegistry(components: Record<string, any>): ComponentRegistryAnalysis;
 
-// @public (undocumented)
-export type BasicInput = z.infer<typeof BasicInputSchema>;
+// @public
+export interface BasicInput {
+    condition?: string | Function;
+    configs?: ConfigsProps;
+    defaultValue?: unknown;
+    helpText?: string;
+    label?: string;
+    name: string;
+    placeholder?: string;
+    shouldRevalidate?: boolean;
+    type: InputType;
+}
 
-// @public (undocumented)
+// @public
 export const BasicInputSchema: z.ZodObject<{
     type: z.ZodUnion<readonly [z.ZodLiteral<"heading">, z.ZodLiteral<"text">, z.ZodLiteral<"richtext">, z.ZodLiteral<"textarea">, z.ZodLiteral<"url">, z.ZodLiteral<"image">, z.ZodLiteral<"video">, z.ZodLiteral<"switch">, z.ZodLiteral<"range">, z.ZodLiteral<"select">, z.ZodLiteral<"position">, z.ZodLiteral<"product">, z.ZodLiteral<"product-list">, z.ZodLiteral<"collection">, z.ZodLiteral<"collection-list">, z.ZodLiteral<"blog">, z.ZodLiteral<"metaobject">, z.ZodLiteral<"color">, z.ZodLiteral<"datepicker">, z.ZodLiteral<"map-autocomplete">, z.ZodLiteral<"toggle-group">]>;
     name: z.ZodString;
     label: z.ZodOptional<z.ZodString>;
     placeholder: z.ZodOptional<z.ZodString>;
     helpText: z.ZodOptional<z.ZodString>;
-    configs: z.ZodOptional<z.ZodCustom<{
-        options?: {
-            label: string;
-            value: string;
-        }[] | undefined;
-    } | {
-        options?: {
-            label: string;
-            value: string;
-            icon?: string | undefined;
-        }[] | undefined;
-    } | {
-        min?: number | undefined;
-        max?: number | undefined;
-        step?: number | undefined;
-        unit?: string | undefined;
-    } | undefined, {
-        options?: {
-            label: string;
-            value: string;
-        }[] | undefined;
-    } | {
-        options?: {
-            label: string;
-            value: string;
-            icon?: string | undefined;
-        }[] | undefined;
-    } | {
-        min?: number | undefined;
-        max?: number | undefined;
-        step?: number | undefined;
-        unit?: string | undefined;
-    } | undefined>>;
+    configs: z.ZodOptional<z.ZodCustom<ConfigsProps | undefined, ConfigsProps | undefined>>;
     shouldRevalidate: z.ZodOptional<z.ZodBoolean>;
     condition: z.ZodOptional<z.ZodUnknown> & z.ZodType<string | Function | undefined, unknown, z.core.$ZodTypeInternals<string | Function | undefined, unknown>>;
     defaultValue: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber, z.ZodBoolean, z.ZodRecord<z.ZodString, z.ZodUnknown>, z.ZodUnknown]>>;
 }, z.core.$strip>;
 
-// @public (undocumented)
+// @public
 export interface ComponentAvailabilityContext {
     group: ComponentGroup;
     page: {
@@ -85,29 +46,67 @@ export interface ComponentAvailabilityContext {
     };
 }
 
-// @public (undocumented)
+// @public
 export type ComponentGroup = 'body' | 'header' | 'footer';
 
-// @public (undocumented)
-export type ComponentPresets = z.infer<typeof ComponentPresetsSchema>;
+// @public
+export interface ComponentPresets {
+    [key: string]: any;
+    children?: any[];
+    type: string;
+}
 
-// @public (undocumented)
+// @public
 export const ComponentPresetsSchema: z.ZodObject<{
     type: z.ZodString;
     children: z.ZodOptional<z.ZodArray<z.ZodLazy<z.ZodType<any, unknown, z.core.$ZodTypeInternals<any, unknown>>>>>;
 }, z.core.$catchall<z.ZodAny>>;
 
-// @public (undocumented)
-export type ComponentValidationOptions = {
-    validate?: boolean;
-    skipMissing?: boolean;
+// @public
+export interface ComponentRegistryAnalysis {
+    details: ComponentRegistryDetail[];
+    summary: ComponentRegistrySummary;
+}
+
+// @public
+export interface ComponentRegistryDetail {
+    error?: string;
+    hasPresets?: boolean;
+    name: string;
+    settingsCount?: number;
+    title?: string;
+    type?: string;
+    valid: boolean;
+}
+
+// @public
+export interface ComponentRegistrySummary {
+    duplicateTypes: string[];
+    invalid: number;
+    total: number;
+    types: string[];
+    valid: number;
+}
+
+// @public
+export interface ComponentsValidationResult {
+    invalid: InvalidComponentResult[];
+    success: boolean;
+    total: number;
+    valid: string[];
+}
+
+// @public
+export interface ComponentValidationOptions {
     logErrors?: boolean;
-};
+    skipMissing?: boolean;
+    validate?: boolean;
+}
 
-// @public (undocumented)
-export type ConfigsProps = z.infer<typeof ConfigsPropsSchema>;
+// @public
+export type ConfigsProps = SelectInputConfigs | ToggleGroupConfigs | RangeInputConfigs;
 
-// @public (undocumented)
+// @public
 export const ConfigsPropsSchema: z.ZodUnion<readonly [z.ZodObject<{
     options: z.ZodOptional<z.ZodArray<z.ZodObject<{
         label: z.ZodString;
@@ -154,7 +153,7 @@ export const devTools: {
     generateTypeInterface: (schema: SchemaType) => string;
 };
 
-// @public (undocumented)
+// @public
 export const ElementSchema: z.ZodObject<{
     title: z.ZodString;
     type: z.ZodString;
@@ -167,39 +166,7 @@ export const ElementSchema: z.ZodObject<{
             label: z.ZodOptional<z.ZodString>;
             placeholder: z.ZodOptional<z.ZodString>;
             helpText: z.ZodOptional<z.ZodString>;
-            configs: z.ZodOptional<z.ZodCustom<{
-                options?: {
-                    label: string;
-                    value: string;
-                }[] | undefined;
-            } | {
-                options?: {
-                    label: string;
-                    value: string;
-                    icon?: string | undefined;
-                }[] | undefined;
-            } | {
-                min?: number | undefined;
-                max?: number | undefined;
-                step?: number | undefined;
-                unit?: string | undefined;
-            } | undefined, {
-                options?: {
-                    label: string;
-                    value: string;
-                }[] | undefined;
-            } | {
-                options?: {
-                    label: string;
-                    value: string;
-                    icon?: string | undefined;
-                }[] | undefined;
-            } | {
-                min?: number | undefined;
-                max?: number | undefined;
-                step?: number | undefined;
-                unit?: string | undefined;
-            } | undefined>>;
+            configs: z.ZodOptional<z.ZodCustom<ConfigsProps | undefined, ConfigsProps | undefined>>;
             shouldRevalidate: z.ZodOptional<z.ZodBoolean>;
             condition: z.ZodOptional<z.ZodUnknown> & z.ZodType<string | Function | undefined, unknown, z.core.$ZodTypeInternals<string | Function | undefined, unknown>>;
             defaultValue: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber, z.ZodBoolean, z.ZodRecord<z.ZodString, z.ZodUnknown>, z.ZodUnknown]>>;
@@ -216,39 +183,7 @@ export const ElementSchema: z.ZodObject<{
             label: z.ZodOptional<z.ZodString>;
             placeholder: z.ZodOptional<z.ZodString>;
             helpText: z.ZodOptional<z.ZodString>;
-            configs: z.ZodOptional<z.ZodCustom<{
-                options?: {
-                    label: string;
-                    value: string;
-                }[] | undefined;
-            } | {
-                options?: {
-                    label: string;
-                    value: string;
-                    icon?: string | undefined;
-                }[] | undefined;
-            } | {
-                min?: number | undefined;
-                max?: number | undefined;
-                step?: number | undefined;
-                unit?: string | undefined;
-            } | undefined, {
-                options?: {
-                    label: string;
-                    value: string;
-                }[] | undefined;
-            } | {
-                options?: {
-                    label: string;
-                    value: string;
-                    icon?: string | undefined;
-                }[] | undefined;
-            } | {
-                min?: number | undefined;
-                max?: number | undefined;
-                step?: number | undefined;
-                unit?: string | undefined;
-            } | undefined>>;
+            configs: z.ZodOptional<z.ZodCustom<ConfigsProps | undefined, ConfigsProps | undefined>>;
             shouldRevalidate: z.ZodOptional<z.ZodBoolean>;
             condition: z.ZodOptional<z.ZodUnknown> & z.ZodType<string | Function | undefined, unknown, z.core.$ZodTypeInternals<string | Function | undefined, unknown>>;
             defaultValue: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber, z.ZodBoolean, z.ZodRecord<z.ZodString, z.ZodUnknown>, z.ZodUnknown]>>;
@@ -280,17 +215,21 @@ export const groupHelpers: {
     custom: (groupName: string, inputs: (BasicInput | HeadingInput)[]) => InspectorGroup;
 };
 
-// @public (undocumented)
-export type HeadingInput = z.infer<typeof HeadingInputSchema>;
+// @public
+export interface HeadingInput {
+    [key: string]: unknown;
+    label: string;
+    type: 'heading';
+}
 
-// @public (undocumented)
+// @public
 export const HeadingInputSchema: z.ZodObject<{
     type: z.ZodLiteral<"heading">;
     label: z.ZodString;
 }, z.core.$loose>;
 
-// @public (undocumented)
-export type Input = z.infer<typeof InputSchema>;
+// @public
+export type Input = BasicInput | HeadingInput;
 
 // @public
 export const inputHelpers: {
@@ -306,46 +245,14 @@ export const inputHelpers: {
     heading: (label: string, options?: Omit<HeadingInput, "type" | "label">) => HeadingInput;
 };
 
-// @public (undocumented)
+// @public
 export const InputSchema: z.ZodUnion<readonly [z.ZodObject<{
     type: z.ZodUnion<readonly [z.ZodLiteral<"heading">, z.ZodLiteral<"text">, z.ZodLiteral<"richtext">, z.ZodLiteral<"textarea">, z.ZodLiteral<"url">, z.ZodLiteral<"image">, z.ZodLiteral<"video">, z.ZodLiteral<"switch">, z.ZodLiteral<"range">, z.ZodLiteral<"select">, z.ZodLiteral<"position">, z.ZodLiteral<"product">, z.ZodLiteral<"product-list">, z.ZodLiteral<"collection">, z.ZodLiteral<"collection-list">, z.ZodLiteral<"blog">, z.ZodLiteral<"metaobject">, z.ZodLiteral<"color">, z.ZodLiteral<"datepicker">, z.ZodLiteral<"map-autocomplete">, z.ZodLiteral<"toggle-group">]>;
     name: z.ZodString;
     label: z.ZodOptional<z.ZodString>;
     placeholder: z.ZodOptional<z.ZodString>;
     helpText: z.ZodOptional<z.ZodString>;
-    configs: z.ZodOptional<z.ZodCustom<{
-        options?: {
-            label: string;
-            value: string;
-        }[] | undefined;
-    } | {
-        options?: {
-            label: string;
-            value: string;
-            icon?: string | undefined;
-        }[] | undefined;
-    } | {
-        min?: number | undefined;
-        max?: number | undefined;
-        step?: number | undefined;
-        unit?: string | undefined;
-    } | undefined, {
-        options?: {
-            label: string;
-            value: string;
-        }[] | undefined;
-    } | {
-        options?: {
-            label: string;
-            value: string;
-            icon?: string | undefined;
-        }[] | undefined;
-    } | {
-        min?: number | undefined;
-        max?: number | undefined;
-        step?: number | undefined;
-        unit?: string | undefined;
-    } | undefined>>;
+    configs: z.ZodOptional<z.ZodCustom<ConfigsProps | undefined, ConfigsProps | undefined>>;
     shouldRevalidate: z.ZodOptional<z.ZodBoolean>;
     condition: z.ZodOptional<z.ZodUnknown> & z.ZodType<string | Function | undefined, unknown, z.core.$ZodTypeInternals<string | Function | undefined, unknown>>;
     defaultValue: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber, z.ZodBoolean, z.ZodRecord<z.ZodString, z.ZodUnknown>, z.ZodUnknown]>>;
@@ -354,16 +261,19 @@ export const InputSchema: z.ZodUnion<readonly [z.ZodObject<{
     label: z.ZodString;
 }, z.core.$loose>]>;
 
-// @public (undocumented)
-export type InputType = z.infer<typeof inputTypeSchema>;
+// @public
+export type InputType = 'heading' | 'text' | 'richtext' | 'textarea' | 'url' | 'image' | 'video' | 'switch' | 'range' | 'select' | 'position' | 'product' | 'product-list' | 'collection' | 'collection-list' | 'blog' | 'metaobject' | 'color' | 'datepicker' | 'map-autocomplete' | 'toggle-group';
 
-// @public (undocumented)
+// @public
 export const inputTypeSchema: z.ZodUnion<readonly [z.ZodLiteral<"heading">, z.ZodLiteral<"text">, z.ZodLiteral<"richtext">, z.ZodLiteral<"textarea">, z.ZodLiteral<"url">, z.ZodLiteral<"image">, z.ZodLiteral<"video">, z.ZodLiteral<"switch">, z.ZodLiteral<"range">, z.ZodLiteral<"select">, z.ZodLiteral<"position">, z.ZodLiteral<"product">, z.ZodLiteral<"product-list">, z.ZodLiteral<"collection">, z.ZodLiteral<"collection-list">, z.ZodLiteral<"blog">, z.ZodLiteral<"metaobject">, z.ZodLiteral<"color">, z.ZodLiteral<"datepicker">, z.ZodLiteral<"map-autocomplete">, z.ZodLiteral<"toggle-group">]>;
 
-// @public (undocumented)
-export type InspectorGroup = z.infer<typeof InspectorGroupSchema>;
+// @public
+export interface InspectorGroup {
+    group: string;
+    inputs: Input[];
+}
 
-// @public (undocumented)
+// @public
 export const InspectorGroupSchema: z.ZodObject<{
     group: z.ZodString;
     inputs: z.ZodArray<z.ZodUnion<readonly [z.ZodObject<{
@@ -372,39 +282,7 @@ export const InspectorGroupSchema: z.ZodObject<{
         label: z.ZodOptional<z.ZodString>;
         placeholder: z.ZodOptional<z.ZodString>;
         helpText: z.ZodOptional<z.ZodString>;
-        configs: z.ZodOptional<z.ZodCustom<{
-            options?: {
-                label: string;
-                value: string;
-            }[] | undefined;
-        } | {
-            options?: {
-                label: string;
-                value: string;
-                icon?: string | undefined;
-            }[] | undefined;
-        } | {
-            min?: number | undefined;
-            max?: number | undefined;
-            step?: number | undefined;
-            unit?: string | undefined;
-        } | undefined, {
-            options?: {
-                label: string;
-                value: string;
-            }[] | undefined;
-        } | {
-            options?: {
-                label: string;
-                value: string;
-                icon?: string | undefined;
-            }[] | undefined;
-        } | {
-            min?: number | undefined;
-            max?: number | undefined;
-            step?: number | undefined;
-            unit?: string | undefined;
-        } | undefined>>;
+        configs: z.ZodOptional<z.ZodCustom<ConfigsProps | undefined, ConfigsProps | undefined>>;
         shouldRevalidate: z.ZodOptional<z.ZodBoolean>;
         condition: z.ZodOptional<z.ZodUnknown> & z.ZodType<string | Function | undefined, unknown, z.core.$ZodTypeInternals<string | Function | undefined, unknown>>;
         defaultValue: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber, z.ZodBoolean, z.ZodRecord<z.ZodString, z.ZodUnknown>, z.ZodUnknown]>>;
@@ -415,37 +293,37 @@ export const InspectorGroupSchema: z.ZodObject<{
 }, z.core.$strip>;
 
 // @public
+export interface InvalidComponentResult {
+    details?: string[];
+    error: string;
+    name: string;
+}
+
+// @public
 export function isValidSchema(schema: unknown): schema is SchemaType;
 
 // @public
 export function mergeSchemas(base: SchemaType, ...overrides: Partial<SchemaType>[]): SchemaType;
 
-// @public (undocumented)
+// @public
 export type OpenGraphType = 'website' | 'article' | 'product' | 'profile' | 'video.other';
 
 // @public
 export interface PageSEOData {
-    // (undocumented)
     canonicalUrl?: string;
-    // (undocumented)
     description?: string;
-    // (undocumented)
     keywords?: string;
-    // (undocumented)
     openGraph?: {
         title?: string;
         description?: string;
         image?: string;
         type?: OpenGraphType;
     };
-    // (undocumented)
     robots?: {
         index?: boolean;
         follow?: boolean;
     };
-    // (undocumented)
     title?: string;
-    // (undocumented)
     twitter?: {
         cardType?: TwitterCardType;
         title?: string;
@@ -454,19 +332,24 @@ export interface PageSEOData {
     };
 }
 
-// @public (undocumented)
-export type PageType = z.infer<typeof PageTypeSchema>;
+// @public
+export type PageType = '*' | 'INDEX' | 'PRODUCT' | 'ALL_PRODUCTS' | 'COLLECTION' | 'COLLECTION_LIST' | 'PAGE' | 'BLOG' | 'ARTICLE' | 'CUSTOM';
 
-// @public (undocumented)
+// @public
 export const PageTypeSchema: z.ZodUnion<readonly [z.ZodLiteral<"*">, z.ZodLiteral<"INDEX">, z.ZodLiteral<"PRODUCT">, z.ZodLiteral<"ALL_PRODUCTS">, z.ZodLiteral<"COLLECTION">, z.ZodLiteral<"COLLECTION_LIST">, z.ZodLiteral<"PAGE">, z.ZodLiteral<"BLOG">, z.ZodLiteral<"ARTICLE">, z.ZodLiteral<"CUSTOM">]>;
 
 // @public
 export function parseSchema(schema: unknown): SchemaType;
 
-// @public (undocumented)
-export type RangeInputConfigs = z.infer<typeof RangeInputConfigsSchema>;
+// @public
+export interface RangeInputConfigs {
+    max?: number;
+    min?: number;
+    step?: number;
+    unit?: string;
+}
 
-// @public (undocumented)
+// @public
 export const RangeInputConfigsSchema: z.ZodObject<{
     min: z.ZodOptional<z.ZodNumber>;
     max: z.ZodOptional<z.ZodNumber>;
@@ -474,40 +357,31 @@ export const RangeInputConfigsSchema: z.ZodObject<{
     unit: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 
-// @public (undocumented)
+// @public
 export type Resolvable<T, Context> = T | ((context: Context) => T);
 
 // @public
 export class SchemaBuilder {
     constructor(initial?: Partial<SchemaType>);
-    // (undocumented)
     addChildType(childType: string): SchemaBuilder;
-    // (undocumented)
     addSetting(group: InspectorGroup): SchemaBuilder;
     build(): SchemaType;
     buildUnsafe(): SchemaType;
-    // (undocumented)
     childTypes(childTypes: string[]): SchemaBuilder;
-    // (undocumented)
     enabled(enabled: SchemaType['enabled']): SchemaBuilder;
-    // @deprecated (undocumented)
+    // @deprecated
     enabledOn(enabledOn: SchemaType['enabledOn']): SchemaBuilder;
-    // (undocumented)
     limit(limit: number): SchemaBuilder;
-    // (undocumented)
     presets(presets: SchemaType['presets']): SchemaBuilder;
-    // (undocumented)
     settings(settings: InspectorGroup[]): SchemaBuilder;
-    // (undocumented)
     title(title: string): SchemaBuilder;
-    // (undocumented)
     type(type: string): SchemaBuilder;
 }
 
 // @public
 export function schemaBuilder(initial?: Partial<SchemaType>): SchemaBuilder;
 
-// @public (undocumented)
+// @public
 export const SchemaList: z.ZodRecord<z.ZodString, z.ZodObject<{
     title: z.ZodString;
     type: z.ZodString;
@@ -520,39 +394,7 @@ export const SchemaList: z.ZodRecord<z.ZodString, z.ZodObject<{
             label: z.ZodOptional<z.ZodString>;
             placeholder: z.ZodOptional<z.ZodString>;
             helpText: z.ZodOptional<z.ZodString>;
-            configs: z.ZodOptional<z.ZodCustom<{
-                options?: {
-                    label: string;
-                    value: string;
-                }[] | undefined;
-            } | {
-                options?: {
-                    label: string;
-                    value: string;
-                    icon?: string | undefined;
-                }[] | undefined;
-            } | {
-                min?: number | undefined;
-                max?: number | undefined;
-                step?: number | undefined;
-                unit?: string | undefined;
-            } | undefined, {
-                options?: {
-                    label: string;
-                    value: string;
-                }[] | undefined;
-            } | {
-                options?: {
-                    label: string;
-                    value: string;
-                    icon?: string | undefined;
-                }[] | undefined;
-            } | {
-                min?: number | undefined;
-                max?: number | undefined;
-                step?: number | undefined;
-                unit?: string | undefined;
-            } | undefined>>;
+            configs: z.ZodOptional<z.ZodCustom<ConfigsProps | undefined, ConfigsProps | undefined>>;
             shouldRevalidate: z.ZodOptional<z.ZodBoolean>;
             condition: z.ZodOptional<z.ZodUnknown> & z.ZodType<string | Function | undefined, unknown, z.core.$ZodTypeInternals<string | Function | undefined, unknown>>;
             defaultValue: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber, z.ZodBoolean, z.ZodRecord<z.ZodString, z.ZodUnknown>, z.ZodUnknown]>>;
@@ -569,39 +411,7 @@ export const SchemaList: z.ZodRecord<z.ZodString, z.ZodObject<{
             label: z.ZodOptional<z.ZodString>;
             placeholder: z.ZodOptional<z.ZodString>;
             helpText: z.ZodOptional<z.ZodString>;
-            configs: z.ZodOptional<z.ZodCustom<{
-                options?: {
-                    label: string;
-                    value: string;
-                }[] | undefined;
-            } | {
-                options?: {
-                    label: string;
-                    value: string;
-                    icon?: string | undefined;
-                }[] | undefined;
-            } | {
-                min?: number | undefined;
-                max?: number | undefined;
-                step?: number | undefined;
-                unit?: string | undefined;
-            } | undefined, {
-                options?: {
-                    label: string;
-                    value: string;
-                }[] | undefined;
-            } | {
-                options?: {
-                    label: string;
-                    value: string;
-                    icon?: string | undefined;
-                }[] | undefined;
-            } | {
-                min?: number | undefined;
-                max?: number | undefined;
-                step?: number | undefined;
-                unit?: string | undefined;
-            } | undefined>>;
+            configs: z.ZodOptional<z.ZodCustom<ConfigsProps | undefined, ConfigsProps | undefined>>;
             shouldRevalidate: z.ZodOptional<z.ZodBoolean>;
             condition: z.ZodOptional<z.ZodUnknown> & z.ZodType<string | Function | undefined, unknown, z.core.$ZodTypeInternals<string | Function | undefined, unknown>>;
             defaultValue: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber, z.ZodBoolean, z.ZodRecord<z.ZodString, z.ZodUnknown>, z.ZodUnknown]>>;
@@ -624,14 +434,14 @@ export const SchemaList: z.ZodRecord<z.ZodString, z.ZodObject<{
     }, z.core.$catchall<z.ZodAny>>>;
 }, z.core.$strip>>;
 
-// @public (undocumented)
-export type SchemaMigration = {
+// @public
+export interface SchemaMigration {
     from: string;
-    to: string;
     migrate: (oldSchema: any) => SchemaType;
-};
+    to: string;
+}
 
-// @public (undocumented)
+// @public
 export class SchemaRegistry {
     get(name: string): SchemaType | undefined;
     list(): string[];
@@ -649,10 +459,26 @@ export class SchemaRegistry {
 // @public
 export const schemaRegistry: SchemaRegistry;
 
-// @public (undocumented)
-export type SchemaType = Omit<InferredSchemaType, 'enabledOn'> & {
-    enabledOn?: InferredSchemaType['enabledOn'];
-};
+// @public
+export interface SchemaType {
+    childTypes?: string[];
+    enabled?: Resolvable<boolean, ComponentAvailabilityContext>;
+    // @deprecated
+    enabledOn?: {
+        pages?: PageType[];
+        groups?: Array<'*' | ComponentGroup>;
+    };
+    // @deprecated
+    inspector?: InspectorGroup[];
+    limit?: number;
+    presets?: {
+        children?: ComponentPresets[];
+        [key: string]: any;
+    };
+    settings?: InspectorGroup[];
+    title: string;
+    type: string;
+}
 
 // @public
 export type SchemaTypeStrict = SchemaType & {
@@ -660,7 +486,7 @@ export type SchemaTypeStrict = SchemaType & {
     type: string;
 };
 
-// @public (undocumented)
+// @public
 export type SchemaValidationFailure = {
     readonly success: false;
     readonly issues: readonly SchemaValidationIssue[];
@@ -676,20 +502,25 @@ export type SchemaValidationIssue = {
     readonly received?: unknown;
 };
 
-// @public (undocumented)
+// @public
 export type SchemaValidationResult<T> = SchemaValidationSuccess<T> | SchemaValidationFailure;
 
-// @public (undocumented)
+// @public
 export type SchemaValidationSuccess<T> = {
     readonly success: true;
     readonly data: T;
     readonly issues?: undefined;
 };
 
-// @public (undocumented)
-export type SelectInputConfigs = z.infer<typeof SelectInputConfigsSchema>;
+// @public
+export interface SelectInputConfigs {
+    options?: Array<{
+        label: string;
+        value: string;
+    }>;
+}
 
-// @public (undocumented)
+// @public
 export const SelectInputConfigsSchema: z.ZodObject<{
     options: z.ZodOptional<z.ZodArray<z.ZodObject<{
         label: z.ZodString;
@@ -698,20 +529,26 @@ export const SelectInputConfigsSchema: z.ZodObject<{
 }, z.core.$strip>;
 
 // @public
-export type SimpleValidationResult<T = any> = {
-    success: boolean;
+export interface SimpleValidationResult<T = any> {
     data?: T;
-    error?: string;
     details?: string[];
-};
+    error?: string;
+    success: boolean;
+}
 
-// @public (undocumented)
+// @public
 export const titleSchema: z.ZodString;
 
-// @public (undocumented)
-export type ToggleGroupConfigs = z.infer<typeof ToggleGroupConfigsSchema>;
+// @public
+export interface ToggleGroupConfigs {
+    options?: Array<{
+        label: string;
+        value: string;
+        icon?: string;
+    }>;
+}
 
-// @public (undocumented)
+// @public
 export const ToggleGroupConfigsSchema: z.ZodObject<{
     options: z.ZodOptional<z.ZodArray<z.ZodObject<{
         label: z.ZodString;
@@ -720,26 +557,17 @@ export const ToggleGroupConfigsSchema: z.ZodObject<{
     }, z.core.$strip>>>;
 }, z.core.$strip>;
 
-// @public (undocumented)
+// @public
 export type TwitterCardType = 'summary' | 'summary_large_image' | 'app' | 'player';
 
-// @public (undocumented)
+// @public
 export const typeSchema: z.ZodString;
 
 // @public
 export function validateComponentSimple(component: any, componentName?: string): SimpleValidationResult;
 
 // @public
-export function validateComponentsSimple(components: Record<string, any>, options?: ComponentValidationOptions): {
-    success: boolean;
-    valid: string[];
-    invalid: Array<{
-        name: string;
-        error: string;
-        details?: string[];
-    }>;
-    total: number;
-};
+export function validateComponentsSimple(components: Record<string, any>, options?: ComponentValidationOptions): ComponentsValidationResult;
 
 // @public
 export function validateSchema(schema: unknown): SchemaValidationResult<SchemaType>;

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -3,17 +3,19 @@
   "version": "0.11.1",
   "description": "Schema definitions for Weaverse",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "type": "module",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/build-declarations.mjs",
     "clean": "rimraf dist",
-    "test": "vp test --run"
+    "test": "vp test --run",
+    "typecheck": "tsc --noEmit"
   },
   "tsup": {
     "entry": [

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -5,7 +5,7 @@ import type {
   RangeInputConfigs,
   SchemaType,
   SchemaValidationIssue,
-} from './validation'
+} from './validation.js'
 
 // `process` is statically replaced by the consuming bundler (Vite/Hydrogen)
 // at build time; this ambient declaration only satisfies the type checker in a
@@ -16,7 +16,7 @@ export type {
   OpenGraphType,
   PageSEOData,
   TwitterCardType,
-} from './page-seo'
+} from './page-seo.js'
 
 /** Schema type with required title and type fields in non-strict projects. */
 export type SchemaTypeStrict = SchemaType & {
@@ -89,30 +89,36 @@ export function createSchemaTypeSafe(schema: SchemaTypeStrict): SchemaType {
 export class SchemaBuilder {
   private readonly schema: Partial<SchemaType>
 
+  /** Creates a builder initialized with an optional partial schema. */
   constructor(initial?: Partial<SchemaType>) {
     this.schema = { ...initial }
   }
 
+  /** Sets the merchant-facing component title. */
   title(title: string): SchemaBuilder {
     this.schema.title = title
     return this
   }
 
+  /** Sets the stable component type identifier. */
   type(type: string): SchemaBuilder {
     this.schema.type = type
     return this
   }
 
+  /** Sets the maximum number of allowed sibling instances. */
   limit(limit: number): SchemaBuilder {
     this.schema.limit = limit
     return this
   }
 
+  /** Replaces all Studio setting groups. */
   settings(settings: InspectorGroup[]): SchemaBuilder {
     this.schema.settings = settings
     return this
   }
 
+  /** Appends one Studio setting group. */
   addSetting(group: InspectorGroup): SchemaBuilder {
     if (!this.schema.settings) {
       this.schema.settings = []
@@ -121,11 +127,13 @@ export class SchemaBuilder {
     return this
   }
 
+  /** Replaces the allowed direct child component types. */
   childTypes(childTypes: string[]): SchemaBuilder {
     this.schema.childTypes = childTypes
     return this
   }
 
+  /** Appends one allowed direct child component type. */
   addChildType(childType: string): SchemaBuilder {
     if (!this.schema.childTypes) {
       this.schema.childTypes = []
@@ -134,17 +142,22 @@ export class SchemaBuilder {
     return this
   }
 
-  /** @deprecated Use {@link enabled} instead. */
+  /**
+   * Sets legacy page and placement restrictions.
+   * @deprecated Use {@link enabled} instead.
+   */
   enabledOn(enabledOn: SchemaType['enabledOn']): SchemaBuilder {
     this.schema.enabledOn = enabledOn
     return this
   }
 
+  /** Sets static or context-aware component availability. */
   enabled(enabled: SchemaType['enabled']): SchemaBuilder {
     this.schema.enabled = enabled
     return this
   }
 
+  /** Sets initial component data and optional child presets. */
   presets(presets: SchemaType['presets']): SchemaBuilder {
     this.schema.presets = presets
     return this
@@ -367,12 +380,17 @@ export type {
   ComponentAvailabilityContext,
   ComponentGroup,
   ComponentPresets,
+  ComponentRegistryAnalysis,
+  ComponentRegistryDetail,
+  ComponentRegistrySummary,
+  ComponentsValidationResult,
   ComponentValidationOptions,
   ConfigsProps,
   HeadingInput,
   Input,
   InputType,
   InspectorGroup,
+  InvalidComponentResult,
   PageType,
   RangeInputConfigs,
   Resolvable,
@@ -386,7 +404,7 @@ export type {
   SimpleValidationResult,
   ToggleGroupConfigs,
   VersionedSchema,
-} from './validation'
+} from './validation.js'
 // Re-export the schema definitions and validation runtime. These are
 // tree-shakeable: storefront bundles that only call `createSchema` never
 // reference them, so `./validation` (and zod) is dropped from production builds.
@@ -417,4 +435,4 @@ export {
   validateComponentsSimple,
   validateSchema,
   z,
-} from './validation'
+} from './validation.js'

--- a/packages/schema/src/page-seo.ts
+++ b/packages/schema/src/page-seo.ts
@@ -10,28 +10,46 @@
  * @see https://github.com/Weaverse/builder — `app/schemas/page-seo.ts`
  */
 export interface PageSEOData {
+  /** Canonical URL advertised to search engines. */
   canonicalUrl?: string
+  /** Search-result description. */
   description?: string
+  /** Comma-separated search keywords. */
   keywords?: string
+  /** Open Graph metadata used by social platforms. */
   openGraph?: {
+    /** Social preview title. */
     title?: string
+    /** Social preview description. */
     description?: string
+    /** Absolute social preview image URL. */
     image?: string
+    /** Open Graph content type. */
     type?: OpenGraphType
   }
+  /** Search-engine crawling directives. */
   robots?: {
+    /** Whether search engines may index the page. */
     index?: boolean
+    /** Whether search engines may follow page links. */
     follow?: boolean
   }
+  /** Search-result and browser title. */
   title?: string
+  /** X/Twitter card metadata. */
   twitter?: {
+    /** Card presentation style. */
     cardType?: TwitterCardType
+    /** Card title. */
     title?: string
+    /** Card description. */
     description?: string
+    /** Absolute card image URL. */
     image?: string
   }
 }
 
+/** Open Graph object types supported by Weaverse page metadata. */
 export type OpenGraphType =
   | 'website'
   | 'article'
@@ -39,6 +57,7 @@ export type OpenGraphType =
   | 'profile'
   | 'video.other'
 
+/** X/Twitter card types supported by Weaverse page metadata. */
 export type TwitterCardType =
   | 'summary'
   | 'summary_large_image'

--- a/packages/schema/src/validation.ts
+++ b/packages/schema/src/validation.ts
@@ -9,6 +9,7 @@ import { z } from 'zod/v4'
 // Re-export Zod for backward compatibility and convenience
 export { z }
 
+/** Runtime validator for supported Studio input control types. */
 export const inputTypeSchema = z.union([
   z.literal('heading'),
   z.literal('text'),
@@ -33,6 +34,7 @@ export const inputTypeSchema = z.union([
   z.literal('toggle-group'),
 ])
 
+/** Runtime validator for select input configuration. */
 export const SelectInputConfigsSchema = z.object({
   options: z
     .array(
@@ -44,6 +46,7 @@ export const SelectInputConfigsSchema = z.object({
     .optional(),
 })
 
+/** Runtime validator for toggle-group input configuration. */
 export const ToggleGroupConfigsSchema = z.object({
   options: z
     .array(
@@ -56,6 +59,7 @@ export const ToggleGroupConfigsSchema = z.object({
     .optional(),
 })
 
+/** Runtime validator for numeric range input configuration. */
 export const RangeInputConfigsSchema = z.object({
   min: z.number().optional(),
   max: z.number().optional(),
@@ -63,12 +67,14 @@ export const RangeInputConfigsSchema = z.object({
   unit: z.string().optional(),
 })
 
+/** Runtime validator for input-specific configuration. */
 export const ConfigsPropsSchema = z.union([
   SelectInputConfigsSchema,
   ToggleGroupConfigsSchema,
   RangeInputConfigsSchema,
 ])
 
+/** Runtime validator for configurable Studio inputs. */
 export const BasicInputSchema = z
   .object({
     type: inputTypeSchema,
@@ -151,6 +157,7 @@ export const BasicInputSchema = z
     }
   })
 
+/** Runtime validator for organizational setting headings. */
 export const HeadingInputSchema = z
   .object({
     type: z.literal('heading'),
@@ -158,8 +165,10 @@ export const HeadingInputSchema = z
   })
   .passthrough() // Allow additional properties with [key: string]: any
 
+/** Runtime validator for settings and organizational headings. */
 export const InputSchema = z.union([BasicInputSchema, HeadingInputSchema])
 
+/** Runtime validator for a labeled group of component settings. */
 export const InspectorGroupSchema = z.object({
   group: z
     .string()
@@ -171,6 +180,7 @@ export const InspectorGroupSchema = z.object({
     .describe('The inputs of the group'),
 })
 
+/** Runtime validator for storefront page types. */
 export const PageTypeSchema = z.union([
   z.literal('*'),
   z.literal('INDEX'),
@@ -184,10 +194,13 @@ export const PageTypeSchema = z.union([
   z.literal('CUSTOM'),
 ])
 
+/** A static value or a synchronous callback deriving it from context. */
 export type Resolvable<T, Context> = T | ((context: Context) => T)
 
+/** Placement groups understood by component availability rules. */
 export type ComponentGroup = 'body' | 'header' | 'footer'
 
+/** Context passed to function-based component availability rules. */
 export interface ComponentAvailabilityContext {
   /** Placement group currently being evaluated. */
   group: ComponentGroup
@@ -204,6 +217,7 @@ export interface ComponentAvailabilityContext {
   }
 }
 
+/** Runtime validator for nested component presets. */
 export const ComponentPresetsSchema = z
   .object({
     type: z.string().describe('The type of the component'),
@@ -215,6 +229,7 @@ export const ComponentPresetsSchema = z
   .catchall(z.any())
   .describe('Component preset configuration')
 
+/** Runtime validator for public component schemas. */
 export const ElementSchema = z
   .object({
     title: z
@@ -288,13 +303,16 @@ export const ElementSchema = z
   })
   .describe('The schema of the element')
 
+/** Runtime validator for a component-type-to-schema registry. */
 export const SchemaList = z.record(z.string(), ElementSchema)
 
 // section schema
+/** Runtime validator for standalone schema titles. */
 export const titleSchema = z
   .string()
   .min(3, 'Title must be at least 3 characters')
   .max(50, 'Title must be less than 50 characters')
+/** Runtime validator for standalone schema type identifiers. */
 export const typeSchema = z
   .string()
   .min(3, 'Type must be at least 3 characters')
@@ -308,30 +326,187 @@ export const typeSchema = z
     'Type cannot start or end with a hyphen'
   )
 
-// Type exports - inferred from Zod schemas
+// Public authoring contracts. Runtime alignment is verified in
+// test/type-alignment.test.ts against each schema's z.output type.
 
-type InferredSchemaType = z.infer<typeof ElementSchema>
+/** Input controls supported by Weaverse Studio. */
+export type InputType =
+  | 'heading'
+  | 'text'
+  | 'richtext'
+  | 'textarea'
+  | 'url'
+  | 'image'
+  | 'video'
+  | 'switch'
+  | 'range'
+  | 'select'
+  | 'position'
+  | 'product'
+  | 'product-list'
+  | 'collection'
+  | 'collection-list'
+  | 'blog'
+  | 'metaobject'
+  | 'color'
+  | 'datepicker'
+  | 'map-autocomplete'
+  | 'toggle-group'
 
-export type SchemaType = Omit<InferredSchemaType, 'enabledOn'> & {
-  /**
-   * @deprecated Use `enabled` for both static and context-aware availability
-   * rules. Existing schemas remain supported, and both rules must pass when
-   * both properties are present.
-   */
-  enabledOn?: InferredSchemaType['enabledOn']
+/** Configuration for a select input. */
+export interface SelectInputConfigs {
+  /** Choices shown in the select menu. */
+  options?: Array<{
+    /** Merchant-facing option label. */
+    label: string
+    /** Value stored in component data. */
+    value: string
+  }>
 }
 
-export type InputType = z.infer<typeof inputTypeSchema>
-export type BasicInput = z.infer<typeof BasicInputSchema>
-export type HeadingInput = z.infer<typeof HeadingInputSchema>
-export type Input = z.infer<typeof InputSchema>
-export type InspectorGroup = z.infer<typeof InspectorGroupSchema>
-export type PageType = z.infer<typeof PageTypeSchema>
-export type SelectInputConfigs = z.infer<typeof SelectInputConfigsSchema>
-export type ToggleGroupConfigs = z.infer<typeof ToggleGroupConfigsSchema>
-export type RangeInputConfigs = z.infer<typeof RangeInputConfigsSchema>
-export type ConfigsProps = z.infer<typeof ConfigsPropsSchema>
-export type ComponentPresets = z.infer<typeof ComponentPresetsSchema>
+/** Configuration for a toggle-group input. */
+export interface ToggleGroupConfigs {
+  /** Choices shown in the toggle group. */
+  options?: Array<{
+    /** Merchant-facing option label. */
+    label: string
+    /** Value stored in component data. */
+    value: string
+    /** Optional icon name displayed with the option. */
+    icon?: string
+  }>
+}
+
+/** Configuration for a numeric range input. */
+export interface RangeInputConfigs {
+  /** Maximum selectable value. */
+  max?: number
+  /** Minimum selectable value. */
+  min?: number
+  /** Increment between selectable values. */
+  step?: number
+  /** Unit displayed next to the value. */
+  unit?: string
+}
+
+/** Input-specific configuration accepted by Studio controls. */
+export type ConfigsProps =
+  | SelectInputConfigs
+  | ToggleGroupConfigs
+  | RangeInputConfigs
+
+/** A configurable component property shown in Weaverse Studio. */
+export interface BasicInput {
+  /**
+   * Controls whether Studio displays this input for the current component data.
+   * String conditions remain supported but are deprecated; prefer a function.
+   */
+  // biome-ignore lint/complexity/noBannedTypes: preserves the existing public contract inferred by Zod
+  condition?: string | Function
+  /** Control-specific options and constraints. */
+  configs?: ConfigsProps
+  /** Initial value assigned when the component is created. */
+  defaultValue?: unknown
+  /** Supporting guidance shown below the control. */
+  helpText?: string
+  /** Merchant-facing field label. */
+  label?: string
+  /** Component prop name receiving the configured value. */
+  name: string
+  /** Placeholder shown by text-like controls. */
+  placeholder?: string
+  /** Whether changing this value reruns the component loader. */
+  shouldRevalidate?: boolean
+  /** Studio control used to edit the property. */
+  type: InputType
+}
+
+/** A non-editable heading used to organize Studio settings. */
+export interface HeadingInput {
+  /** Text displayed above the following settings. */
+  label: string
+  /** Heading discriminator. */
+  type: 'heading'
+  /** Additional Studio metadata retained for backward compatibility. */
+  [key: string]: unknown
+}
+
+/** A setting input or organizational heading. */
+export type Input = BasicInput | HeadingInput
+
+/** A labeled group of component settings. */
+export interface InspectorGroup {
+  /** Group title displayed in Studio. */
+  group: string
+  /** Settings rendered inside the group. */
+  inputs: Input[]
+}
+
+/** Storefront page types available to component placement rules. */
+export type PageType =
+  | '*'
+  | 'INDEX'
+  | 'PRODUCT'
+  | 'ALL_PRODUCTS'
+  | 'COLLECTION'
+  | 'COLLECTION_LIST'
+  | 'PAGE'
+  | 'BLOG'
+  | 'ARTICLE'
+  | 'CUSTOM'
+
+/** Initial data and nested children created by a component preset. */
+export interface ComponentPresets {
+  /** Nested child component presets retained in their legacy permissive shape. */
+  // biome-ignore lint/suspicious/noExplicitAny: preserves the existing recursive Zod contract
+  children?: any[]
+  /** Registered component type to create. */
+  type: string
+  /** Additional component setting defaults. */
+  // biome-ignore lint/suspicious/noExplicitAny: presets intentionally accept arbitrary component data
+  [key: string]: any
+}
+
+/** Public component schema authoring contract. */
+export interface SchemaType {
+  /** Component types allowed as direct children. */
+  childTypes?: string[]
+  /** Whether the component can be inserted in the current page context. */
+  enabled?: Resolvable<boolean, ComponentAvailabilityContext>
+  /**
+   * Legacy page and placement availability restrictions.
+   * @deprecated Use {@link enabled} for both static and context-aware
+   * availability. Existing schemas remain supported, and both rules must pass
+   * when both properties are present.
+   */
+  enabledOn?: {
+    /** Page types where the component can be inserted. */
+    pages?: PageType[]
+    /** Placement groups where the component can be inserted. */
+    groups?: Array<'*' | ComponentGroup>
+  }
+  /**
+   * Legacy setting groups shown in Studio.
+   * @deprecated Use {@link settings} instead.
+   */
+  inspector?: InspectorGroup[]
+  /** Maximum number of instances allowed under the same parent. */
+  limit?: number
+  /** Initial component data and optional child presets. */
+  presets?: {
+    /** Child components created with the parent. */
+    children?: ComponentPresets[]
+    /** Additional component setting defaults. */
+    // biome-ignore lint/suspicious/noExplicitAny: presets intentionally accept arbitrary component data
+    [key: string]: any
+  }
+  /** Setting groups shown in the Studio inspector. */
+  settings?: InspectorGroup[]
+  /** Short component title displayed in Studio. */
+  title: string
+  /** Stable kebab-case component identifier. */
+  type: string
+}
 
 /**
  * Enhanced validation result types for better error reporting
@@ -349,18 +524,27 @@ export type SchemaValidationIssue = {
   readonly received?: unknown
 }
 
+/** Successful schema validation result. */
 export type SchemaValidationSuccess<T> = {
+  /** Indicates that validation succeeded. */
   readonly success: true
+  /** Validated and normalized value. */
   readonly data: T
+  /** Successful results never contain issues. */
   readonly issues?: undefined
 }
 
+/** Failed schema validation result. */
 export type SchemaValidationFailure = {
+  /** Indicates that validation failed. */
   readonly success: false
+  /** Validation issues found in the input. */
   readonly issues: readonly SchemaValidationIssue[]
+  /** Failed results never contain validated data. */
   readonly data?: undefined
 }
 
+/** Discriminated result returned by schema validation helpers. */
 export type SchemaValidationResult<T> =
   | SchemaValidationSuccess<T>
   | SchemaValidationFailure
@@ -439,12 +623,17 @@ export interface VersionedSchema extends SchemaType {
   readonly version?: string
 }
 
-export type SchemaMigration = {
+/** Migration between two schema versions. */
+export interface SchemaMigration {
+  /** Source schema version. */
   from: string
-  to: string
+  /** Transforms data from the source version to the target version. */
   migrate: (oldSchema: any) => SchemaType
+  /** Target schema version. */
+  to: string
 }
 
+/** In-memory registry for schemas and their migrations. */
 export class SchemaRegistry {
   private readonly schemas = new Map<string, SchemaType>()
   private readonly migrations = new Map<string, SchemaMigration[]>()
@@ -630,17 +819,48 @@ export const devTools = {
  * with minimal dependencies and clean error reporting.
  */
 
-export type SimpleValidationResult<T = any> = {
-  success: boolean
+/** Result returned by lightweight component validation. */
+export interface SimpleValidationResult<T = any> {
+  /** Validated component metadata when successful. */
   data?: T
-  error?: string
+  /** Individual validation issue messages. */
   details?: string[]
+  /** Human-readable failure summary. */
+  error?: string
+  /** Whether validation succeeded. */
+  success: boolean
 }
 
-export type ComponentValidationOptions = {
-  validate?: boolean
-  skipMissing?: boolean
+/** One component that failed bulk validation. */
+export interface InvalidComponentResult {
+  /** Individual validation issue messages. */
+  details?: string[]
+  /** Human-readable failure summary. */
+  error: string
+  /** Registry key of the invalid component. */
+  name: string
+}
+
+/** Result returned by bulk component validation. */
+export interface ComponentsValidationResult {
+  /** Components that failed validation. */
+  invalid: InvalidComponentResult[]
+  /** Whether every evaluated component passed validation. */
+  success: boolean
+  /** Total number of entries supplied to validation. */
+  total: number
+  /** Registry keys of valid components. */
+  valid: string[]
+}
+
+/** Options controlling bulk component validation. */
+export interface ComponentValidationOptions {
+  /** Whether validation failures should be logged. */
   logErrors?: boolean
+  /** Whether null or undefined component entries should be ignored. */
+  skipMissing?: boolean
+  /** Whether component schemas should be validated. */
+  validate?: boolean
 }
 
 /**
@@ -704,15 +924,10 @@ export function validateComponentSimple(
 export function validateComponentsSimple(
   components: Record<string, any>,
   options: ComponentValidationOptions = {}
-): {
-  success: boolean
-  valid: string[]
-  invalid: Array<{ name: string; error: string; details?: string[] }>
-  total: number
-} {
+): ComponentsValidationResult {
   const { skipMissing = false, logErrors = false } = options
   const valid: string[] = []
-  const invalid: Array<{ name: string; error: string; details?: string[] }> = []
+  const invalid: InvalidComponentResult[] = []
 
   for (const [name, component] of Object.entries(components)) {
     if (!component && skipMissing) {
@@ -778,39 +993,54 @@ export function createValidatedComponentArray<T extends Record<string, any>>(
   return Object.values(components)
 }
 
-/**
- * Development helper to analyze component registry
- */
-export function analyzeComponentRegistry(components: Record<string, any>): {
-  summary: {
-    total: number
-    valid: number
-    invalid: number
-    types: string[]
-    duplicateTypes: string[]
-  }
-  details: Array<{
-    name: string
-    type?: string
-    title?: string
-    valid: boolean
-    error?: string
-    settingsCount?: number
-    hasPresets?: boolean
-  }>
-} {
+/** Aggregate statistics for a component registry. */
+export interface ComponentRegistrySummary {
+  /** Component types registered more than once. */
+  duplicateTypes: string[]
+  /** Number of invalid components. */
+  invalid: number
+  /** Number of supplied components. */
+  total: number
+  /** Unique registered component types. */
+  types: string[]
+  /** Number of valid components. */
+  valid: number
+}
+
+/** Validation and schema details for one registered component. */
+export interface ComponentRegistryDetail {
+  /** Human-readable validation failure. */
+  error?: string
+  /** Whether the component defines presets. */
+  hasPresets?: boolean
+  /** Registry key of the component. */
+  name: string
+  /** Number of Studio setting groups. */
+  settingsCount?: number
+  /** Merchant-facing component title. */
+  title?: string
+  /** Registered component type. */
+  type?: string
+  /** Whether the component passed validation. */
+  valid: boolean
+}
+
+/** Result returned by component registry analysis. */
+export interface ComponentRegistryAnalysis {
+  /** Per-component validation and schema details. */
+  details: ComponentRegistryDetail[]
+  /** Aggregate registry statistics. */
+  summary: ComponentRegistrySummary
+}
+
+/** Development helper that analyzes a component registry. */
+export function analyzeComponentRegistry(
+  components: Record<string, any>
+): ComponentRegistryAnalysis {
   const validation = validateComponentsSimple(components)
   const types = new Set<string>()
   const duplicateTypes = new Set<string>()
-  const details: Array<{
-    name: string
-    type?: string
-    title?: string
-    valid: boolean
-    error?: string
-    settingsCount?: number
-    hasPresets?: boolean
-  }> = []
+  const details: ComponentRegistryDetail[] = []
 
   for (const [name, component] of Object.entries(components)) {
     const result = validateComponentSimple(component, name)

--- a/packages/schema/test/type-alignment.test.ts
+++ b/packages/schema/test/type-alignment.test.ts
@@ -1,45 +1,110 @@
+import type { z } from 'zod/v4'
 import type {
   BasicInput,
+  BasicInputSchema,
+  ComponentPresets,
+  ComponentPresetsSchema,
+  ConfigsProps,
+  ConfigsPropsSchema,
+  ElementSchema,
   HeadingInput,
+  HeadingInputSchema,
+  Input,
+  InputSchema,
   InputType,
   InspectorGroup,
+  InspectorGroupSchema,
+  inputTypeSchema,
   PageType,
+  PageTypeSchema,
+  RangeInputConfigs,
+  RangeInputConfigsSchema,
+  SchemaType,
+  SelectInputConfigs,
+  SelectInputConfigsSchema,
+  ToggleGroupConfigs,
+  ToggleGroupConfigsSchema,
 } from '../src'
 
-// Test that types are properly exported and can be used
-const basicInput: BasicInput = {
+type MutuallyAssignable<Left, Right> = [Left] extends [Right]
+  ? [Right] extends [Left]
+    ? true
+    : false
+  : false
+
+type Assert<Condition extends true> = Condition
+
+export type AssertInputType = Assert<
+  MutuallyAssignable<InputType, z.output<typeof inputTypeSchema>>
+>
+export type AssertSelectInputConfigs = Assert<
+  MutuallyAssignable<
+    SelectInputConfigs,
+    z.output<typeof SelectInputConfigsSchema>
+  >
+>
+export type AssertToggleGroupConfigs = Assert<
+  MutuallyAssignable<
+    ToggleGroupConfigs,
+    z.output<typeof ToggleGroupConfigsSchema>
+  >
+>
+export type AssertRangeInputConfigs = Assert<
+  MutuallyAssignable<
+    RangeInputConfigs,
+    z.output<typeof RangeInputConfigsSchema>
+  >
+>
+export type AssertConfigsProps = Assert<
+  MutuallyAssignable<ConfigsProps, z.output<typeof ConfigsPropsSchema>>
+>
+export type AssertBasicInput = Assert<
+  MutuallyAssignable<BasicInput, z.output<typeof BasicInputSchema>>
+>
+export type AssertHeadingInput = Assert<
+  MutuallyAssignable<HeadingInput, z.output<typeof HeadingInputSchema>>
+>
+export type AssertInput = Assert<
+  MutuallyAssignable<Input, z.output<typeof InputSchema>>
+>
+export type AssertInspectorGroup = Assert<
+  MutuallyAssignable<InspectorGroup, z.output<typeof InspectorGroupSchema>>
+>
+export type AssertPageType = Assert<
+  MutuallyAssignable<PageType, z.output<typeof PageTypeSchema>>
+>
+export type AssertComponentPresets = Assert<
+  MutuallyAssignable<ComponentPresets, z.output<typeof ComponentPresetsSchema>>
+>
+export type AssertSchemaType = Assert<
+  MutuallyAssignable<SchemaType, z.output<typeof ElementSchema>>
+>
+
+let basicInput: BasicInput = {
   type: 'text',
   name: 'title',
-  label: 'Title',
-  placeholder: 'Enter title',
-  helpText: 'This is the title',
-  shouldRevalidate: false,
-  condition: 'someCondition',
-  defaultValue: 'Default Title',
+  condition: (data: { showTitle?: boolean }) => data.showTitle ?? true,
+  defaultValue: Symbol('legacy value'),
 }
-
-const headingInput: HeadingInput = {
+let headingInput: HeadingInput = {
   type: 'heading',
-  label: 'Section Settings',
-  // Can have additional properties
-  someExtraProperty: true,
+  label: 'Section settings',
+  customProperty: true,
 }
-
-const _inspectorGroup: InspectorGroup = {
+let legacyPreset: ComponentPresets = {
+  type: 'legacy-preset',
+  children: [123],
+}
+let inspectorGroup: InspectorGroup = {
   group: 'Layout',
   inputs: [basicInput, headingInput],
 }
+let schema: SchemaType = {
+  title: 'Type alignment',
+  type: 'type-alignment',
+  settings: [inspectorGroup],
+  presets: { children: [legacyPreset] },
+  enabled: ({ page }) => page.type === 'PRODUCT',
+}
 
-const _pageType: PageType = 'PRODUCT'
-const _inputType: InputType = 'toggle-group'
-
-// Type assertions to ensure compatibility
-export type AssertBasicInput = BasicInput extends BasicInput ? true : false
-export type AssertHeadingInput = HeadingInput extends HeadingInput
-  ? true
-  : false
-export type AssertInspectorGroup = InspectorGroup extends InspectorGroup
-  ? true
-  : false
-
-console.log('Type alignment test passed!')
+void schema

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -6,5 +6,7 @@
     "paths": {
       "~/*": ["./src/*"]
     }
-  }
+  },
+  "include": ["src/**/*", "test/type-alignment.test.ts"],
+  "exclude": ["dist", "node_modules"]
 }

--- a/scripts/api-reports.mjs
+++ b/scripts/api-reports.mjs
@@ -9,6 +9,7 @@ let REPORT_DIR = join(ROOT_DIR, 'api-reports')
 let TEMP_DIR = join(ROOT_DIR, 'node_modules', '.cache', 'api-reports')
 let RUNTIME_REPORT = join(REPORT_DIR, 'runtime-exports.api.md')
 let UPDATE_REPORTS = process.argv.includes('--update')
+const DOCUMENTED_PACKAGES = new Set(['schema'])
 let publishedPackages = getPublishedPackages(ROOT_DIR)
 let typeEntrypoints = publishedPackages.flatMap((publishedPackage) =>
   publishedPackage.entrypoints
@@ -53,7 +54,9 @@ for (let { publishedPackage, entrypoint } of typeEntrypoints) {
           default: { logLevel: 'error' },
           'ae-forgotten-export': { logLevel: 'none' },
           'ae-missing-release-tag': { logLevel: 'none' },
-          'ae-undocumented': { logLevel: 'none' },
+          'ae-undocumented': {
+            logLevel: DOCUMENTED_PACKAGES.has(folderName) ? 'error' : 'none',
+          },
           'ae-unresolved-link': { logLevel: 'none' },
         },
         tsdocMessageReporting: {

--- a/scripts/check-packed-packages.mjs
+++ b/scripts/check-packed-packages.mjs
@@ -25,8 +25,6 @@ let PNPM = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const RUNTIME_JSON_BLOCK = /```json\n([\s\S]*?)\n```/
 // Next's browser entry imports next/navigation, which is resolved by its bundler.
 const NODE_ESM_EXCLUSIONS = new Set(['@weaverse/next'])
-// Schema's Zod-inferred types change consumer strictness when emitted unbundled.
-const DECLARATION_MAP_EXCLUSIONS = new Set(['@weaverse/schema'])
 let publishedPackages = getPublishedPackages(ROOT_DIR)
 let typeEntrypoints = publishedPackages.flatMap((publishedPackage) =>
   publishedPackage.entrypoints
@@ -81,7 +79,12 @@ function normalizeEntry(entryFile) {
   return entryFile.startsWith('./') ? entryFile.slice(2) : entryFile
 }
 
-function hasDeprecatedEnabledOnProperty(declarationFile) {
+function hasDeprecatedMember(
+  declarationFile,
+  memberName,
+  memberKind,
+  migrationTarget
+) {
   let sourceFile = ts.createSourceFile(
     declarationFile,
     readFileSync(declarationFile, 'utf8'),
@@ -92,14 +95,17 @@ function hasDeprecatedEnabledOnProperty(declarationFile) {
   let found = false
 
   function visit(node) {
-    if (
-      ts.isPropertySignature(node) &&
-      node.name?.getText(sourceFile) === 'enabledOn' &&
-      ts
+    let kindMatches =
+      (memberKind === 'property' && ts.isPropertySignature(node)) ||
+      (memberKind === 'method' && ts.isMethodDeclaration(node))
+    if (kindMatches && node.name?.getText(sourceFile) === memberName) {
+      found = ts
         .getJSDocTags(node)
-        .some((tag) => tag.kind === ts.SyntaxKind.JSDocDeprecatedTag)
-    ) {
-      found = true
+        .some(
+          (tag) =>
+            tag.kind === ts.SyntaxKind.JSDocDeprecatedTag &&
+            tag.getText(sourceFile).includes(migrationTarget)
+        )
     }
     ts.forEachChild(node, visit)
   }
@@ -179,15 +185,13 @@ try {
       }
     }
 
-    let declarationFolders = DECLARATION_MAP_EXCLUSIONS.has(packageJson.name)
-      ? new Set()
-      : new Set(
-          publishedPackage.entrypoints
-            .filter((entrypoint) => entrypoint.types)
-            .map((entrypoint) =>
-              dirname(join(packedFolder, normalizeEntry(entrypoint.types)))
-            )
+    let declarationFolders = new Set(
+      publishedPackage.entrypoints
+        .filter((entrypoint) => entrypoint.types)
+        .map((entrypoint) =>
+          dirname(join(packedFolder, normalizeEntry(entrypoint.types)))
         )
+    )
     let declarationFiles = [...declarationFolders].flatMap((folder) =>
       walk(folder).filter((file) => file.endsWith('.d.ts'))
     )
@@ -223,7 +227,18 @@ try {
     }
   }
 
-  for (let packageName of ['@weaverse/hydrogen', '@weaverse/schema']) {
+  let deprecationRequirements = {
+    '@weaverse/hydrogen': [['enabledOn', 'property', 'enabled']],
+    '@weaverse/schema': [
+      ['enabledOn', 'property', 'enabled'],
+      ['inspector', 'property', 'settings'],
+      ['enabledOn', 'method', 'enabled'],
+    ],
+  }
+
+  for (let [packageName, requirements] of Object.entries(
+    deprecationRequirements
+  )) {
     let publishedPackage = publishedPackages.find(
       (candidate) => candidate.packageJson.name === packageName
     )
@@ -239,10 +254,16 @@ try {
         return walk(dirname(entryFile)).filter((file) => file.endsWith('.d.ts'))
       })
 
-    if (!declarationFiles.some(hasDeprecatedEnabledOnProperty)) {
-      throw new Error(
-        `${packageName} lost enabledOn property deprecation metadata`
-      )
+    for (let [memberName, memberKind, migrationTarget] of requirements) {
+      if (
+        !declarationFiles.some((file) =>
+          hasDeprecatedMember(file, memberName, memberKind, migrationTarget)
+        )
+      ) {
+        throw new Error(
+          `${packageName} lost ${memberName} ${memberKind} migration guidance`
+        )
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Phase 3 of #500 documents and stabilizes the full `@weaverse/schema` public interface:

- replace consumer-compiler-dependent `z.infer` exports with explicit authoring contracts
- prove bidirectional assignability against each runtime schema's `z.output`
- preserve legacy permissive behavior, including recursive preset children
- enable source-preserving declarations and declaration maps for Schema
- document every public Schema symbol and property
- promote missing Schema documentation to a CI error
- strengthen packed deprecation checks for `enabledOn`, `inspector`, and `SchemaBuilder.enabledOn`

## Validation

- `pnpm run biome`
- `pnpm run typecheck` (Schema now participates directly)
- `pnpm run test` (481 passed, 1 skipped)
- `pnpm run package:check`
- Schema API report: 0 undocumented markers
- strict and loose packed consumers pass
- independent review approved

This completes Schema's portion of Phase 3; Core, React, Hydrogen, Experiments, and Next documentation remain under #500.
