### PR TITLE
fix(schema): ship a real CJS build and require condition

### DIFF
--- a/.specs/2026-07-25--schema-cjs-exports/README.md
+++ b/.specs/2026-07-25--schema-cjs-exports/README.md
@@ -1,0 +1,39 @@
+# Feature: Restore CommonJS resolution for `@weaverse/schema`
+
+| Field | Value |
+| --- | --- |
+| **Status** | completed |
+| **Owner** | @paul |
+| **Issue** | [#508](https://github.com/Weaverse/weaverse/issues/508) |
+| **Branch** | `fix/508-schema-cjs-exports` |
+| **Created** | 2026-07-25 |
+| **Last Updated** | 2026-07-25 |
+
+## Original Prompt
+
+> Fix the published package contract so CommonJS consumers of `@weaverse/schema` and the CJS build of
+> `@weaverse/hydrogen` no longer fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Reproduce the exact
+> regression against packed artifacts, add a focused regression check and demonstrate RED before the
+> production change, determine the Node >=20 compatible package design (prefer a real CJS artifact
+> instead of pointing `require` at an ESM file unless the supported Node matrix proves that is valid),
+> apply the smallest robust fix for both the schema root and any affected public subpath such as
+> `@weaverse/schema/manifest`, and make packed-artifact verification cover direct CommonJS schema
+> consumption and the Hydrogen CJS transitive path.
+
+## Summary
+
+`@weaverse/schema@0.13.0` shipped an `exports` map that only declares the `import` condition, so Node
+refuses every `require()` of the package root and of `@weaverse/schema/manifest`. Because
+`@weaverse/hydrogen` still publishes a CJS build that `require`s `@weaverse/schema`, every CommonJS
+consumer of Hydrogen broke as well. This spec ships a real dual (ESM + CJS) schema artifact, adds the
+`require` condition for both public subpaths, and hardens `scripts/check-packed-packages.mjs` so a
+missing `require` condition can never ship again.
+
+## Outcome
+
+- `packages/schema` now builds `esm` + `cjs` with tsup (`dist/*.js` ESM, `dist/*.cjs` CJS).
+- `exports` declares `types` / `import` / `require` for `.` and `./manifest`; `main` points at the CJS
+  artifact for legacy Node10 resolvers.
+- `scripts/check-packed-packages.mjs` now fails when a published entrypoint drops its `require`
+  condition, executes a CommonJS schema/manifest smoke test against the packed tarballs, and
+  typechecks `@weaverse/schema` + `@weaverse/schema/manifest` from a `.cts` consumer.

--- a/.specs/2026-07-25--schema-cjs-exports/plan.md
+++ b/.specs/2026-07-25--schema-cjs-exports/plan.md
@@ -41,12 +41,24 @@ So schema builds `esm` + `cjs` with tsup and declares both conditions.
 | --- | --- | --- |
 | `main` | `dist/index.js` (ESM) | `dist/index.cjs` (CJS, for Node10 resolvers) |
 | `module` | absent | `dist/index.js` |
-| `exports["."]` | `types`, `import` | `types`, `import`, `require: ./dist/index.cjs` |
-| `exports["./manifest"]` | `types`, `import` | `types`, `import`, `require: ./dist/manifest.cjs` |
+| `exports["."]` | `types`, `import` | per-condition `import`/`require` branches, each with its own `types` |
+| `exports["./manifest"]` | `types`, `import` | per-condition `import`/`require` branches, each with its own `types` |
 | `tsup.format` | `["esm"]` | `["esm", "cjs"]` |
 
 `type: "module"` is kept, so `dist/*.js` stays ESM and tsup emits the CJS half as `dist/*.cjs`.
-`dist/types/**` declarations are unchanged and are shared by both conditions.
+
+The `types` condition is nested inside each of `import` and `require` rather than hoisted. A single
+shared `.d.ts` is read by TypeScript as ESM (the package is `type: "module"`), so CommonJS consumers
+on `module: node16`/`node18` fail with **TS1479** even though the runtime `require` works. The
+`require` branch therefore points at `.d.cts` declarations. This applies identically to
+`@weaverse/experiments`, the repo's only other `type: "module"` dual package, which had the same
+latent defect and is fixed in the same way.
+
+### 1b. `scripts/build-declarations.mjs`
+
+For `type: "module"` packages, emit a `.d.cts` sibling for every `dist/types/**/*.d.ts`, rewriting
+relative `./x.js` specifiers to `./x.cjs` so the CommonJS declaration graph stays internally
+consistent under `skipLibCheck: false`. CommonJS packages are untouched.
 
 ### 2. `scripts/check-packed-packages.mjs`
 
@@ -54,16 +66,32 @@ The existing check installed packed tarballs as *direct* dependencies only, so
 `@weaverse/hydrogen`'s transitive `@weaverse/schema` resolved to the published registry copy and
 hid the regression source. Four hardening changes:
 
-1. Write a `pnpm-workspace.yaml` with `overrides` for every packed `@weaverse/*` package in the
-   scratch consumer, so transitive resolution also hits the tarballs under test.
+1. Write a `pnpm-workspace.yaml` with **edge-scoped** `overrides` (`parent>child`) for each internal
+   dependency edge whose declared range still accepts the packed version, so transitive resolution
+   hits the tarballs under test. Edges with incompatible pins (currently `@weaverse/next`, which
+   still declares `@weaverse/schema@0.10.0` and `@weaverse/react@5.16.4`) are deliberately left on
+   registry resolution and reported, preserving the pre-existing install-time coverage for stale or
+   invalid internal metadata instead of masking it behind a blanket override.
 2. Assert every published entrypoint (except `@weaverse/cli`, ESM-only executable, and
    `@weaverse/biome`, JSON-only) declares a `require` condition.
-3. `assertCommonJsArtifact` parses each `require` target and rejects it if it contains ESM
-   `import` / `export` / `export =` statements — this blocks the "point `require` at the ESM file"
-   shortcut from ever landing.
-4. Add `manifest-runtime.cjs`, a CommonJS smoke test that `require`s both `@weaverse/schema` and
+3. `assertCommonJsArtifact` first classifies the require target the way Node does — by extension and
+   the nearest `package.json` `type` — so a `.js` target inside a `type: "module"` package is
+   rejected even when it contains no import/export statement. It then rejects ESM syntax, including
+   `export const` / `export function` / `export class`, which a statement-kind-only check misses.
+4. Assert that a `type: "module"` package resolves its require-condition `types` to `.d.cts`, and
+   that every resolved declaration target actually exists in the tarball.
+5. Add `manifest-runtime.cjs`, a CommonJS smoke test that `require`s both `@weaverse/schema` and
    `@weaverse/schema/manifest` from the packed tarballs and asserts the deterministic manifest hash;
-   and add both specifiers to the existing `consumer.cts` NodeNext CJS typecheck.
+   add both specifiers to the existing `consumer.cts` NodeNext CJS typecheck; and add a
+   `module: node16` CJS typecheck (`node16-consumer.cts`) over the Weaverse packages, which is the
+   mode that actually catches TS1479.
+
+### 2b. `scripts/public-packages.mjs`
+
+`findCondition` searched the exports object depth-first for a condition name anywhere in the tree.
+That is wrong once `types` legally appears inside both the `import` and `require` branches with
+different targets. It now resolves conditions the way Node and TypeScript do — in declaration order,
+following only active or `default` keys — and exposes `requireTypes` alongside `types`.
 
 The pre-existing `runtime.cjs` check already covered the Hydrogen CJS transitive path once the
 overrides were in place — it was the check that went RED on `main`.
@@ -71,7 +99,10 @@ overrides were in place — it was the check that went RED on `main`.
 ## Touched files / packages
 
 - `packages/schema/package.json`
+- `packages/experiments/package.json` (same latent TS1479 defect, same owner boundary)
+- `scripts/build-declarations.mjs`
 - `scripts/check-packed-packages.mjs`
+- `scripts/public-packages.mjs`
 - `.specs/2026-07-25--schema-cjs-exports/{README.md,plan.md}`
 
 No source files, templates, archived packages, dependency upgrades, or version bumps.
@@ -83,6 +114,7 @@ No source files, templates, archived packages, dependency upgrades, or version b
 | `pnpm run package:check` (on `main`) | RED — `ERR_PACKAGE_PATH_NOT_EXPORTED` from `runtime.cjs` |
 | `pnpm run package:check` (fix reverted, guards kept) | RED — `@weaverse/schema has no require condition` |
 | `pnpm run package:check` (`require` → ESM file) | RED — `points its require condition at the ES module` |
+| `pnpm run package:check` (flat shared `types`) | RED — `resolves require-condition types to ./dist/types/index.d.ts, which TypeScript reads as ESM` |
 | `pnpm run package:check` (fixed) | GREEN — `Verified 8 packed packages and 10 TypeScript entrypoints` |
 | `pnpm run test` | GREEN — 8 tasks, 322 tests |
 | `pnpm run typecheck` | GREEN |
@@ -92,8 +124,24 @@ Plus an out-of-tree packed-tarball consumer proving `require('@weaverse/schema')
 `require('@weaverse/schema/manifest')`, and `require('@weaverse/hydrogen')` all resolve, and that
 ESM imports still work.
 
+## Review follow-ups (deliberately not fixed here)
+
+- **Dual-package hazard on `schemaRegistry`.** Building the same entrypoint as both ESM and CJS
+  creates two `SchemaRegistry` classes and two `schemaRegistry` instances, so `instanceof` and
+  registry contents can diverge in a mixed-format process. This is inherent to every dual package in
+  this repo (`core`, `react`, `hydrogen`, `next`, `experiments` all already ship both formats) and
+  converging on one canonical instance means an ESM-wrapper-over-CJS redesign of the build. No
+  Weaverse package or template reads or mutates `schemaRegistry`/`devTools` across a format
+  boundary today, so there is no reachable defect in this PR's scope. Tracked as a follow-up rather
+  than expanded into this fix, per the scope governor.
+- **`@weaverse/next` stale internal pins.** It declares `@weaverse/schema@0.10.0` and
+  `@weaverse/react@5.16.4` while the workspace ships `0.13.0`/`5.19.0`. The packed check now reports
+  these instead of silently overriding them. Correcting the pins is release/version work, which this
+  PR is not allowed to touch.
+
 ## Residual risk
 
 Version bumps and publishing are deliberately out of scope. `@weaverse/schema` must be released
 (minor, since the package contract gains a condition) and `@weaverse/hydrogen` must be re-pinned to
-that version before consumers see the fix.
+that version before consumers see the fix. `@weaverse/experiments` also needs a release to ship its
+TS1479 fix.

--- a/.specs/2026-07-25--schema-cjs-exports/plan.md
+++ b/.specs/2026-07-25--schema-cjs-exports/plan.md
@@ -1,0 +1,99 @@
+# Plan: Restore CommonJS resolution for `@weaverse/schema`
+
+## Problem
+
+`@weaverse/schema@0.13.0` added an `exports` map with only the `import` condition:
+
+```json
+"exports": {
+  ".": { "types": "./dist/types/index.d.ts", "import": "./dist/index.js" },
+  "./manifest": { "types": "./dist/types/manifest.d.ts", "import": "./dist/manifest.js" }
+}
+```
+
+Once an `exports` map exists, Node stops falling back to `main`. Every `require()` of the package
+root and of `./manifest` therefore fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`. `@weaverse/schema@0.12.0`
+had no `exports` map, so `require` fell back to `main` and Node's `require(ESM)` support handled it.
+
+`@weaverse/hydrogen` still publishes a CJS bundle (`dist/index.js`) that contains
+`var schema$1 = require('@weaverse/schema')`, so every CommonJS consumer of Hydrogen broke too.
+
+## Design decision: real CJS artifact, not `require` → ESM
+
+The issue proposes `"require": "./dist/index.js"` (pointing at the ESM file) as one option. That is
+rejected:
+
+- `@weaverse/hydrogen` declares `engines.node >= 20`. Synchronous `require(ESM)` only became
+  unflagged in Node 22.12 / 20.19. On Node 20.0–20.18 it throws `ERR_REQUIRE_ESM`.
+- `require(ESM)` is still refused outright on any Node where the module graph contains top-level
+  `await`, and it changes the shape of the returned namespace object versus a real CJS module.
+  Relying on it makes the published contract depend on the consumer's exact Node patch version.
+- Every other dual package in this repo (`core`, `react`, `hydrogen`, `next`, `experiments`) already
+  ships a real CJS artifact. Schema was the only outlier.
+
+So schema builds `esm` + `cjs` with tsup and declares both conditions.
+
+## Changes
+
+### 1. `packages/schema/package.json`
+
+| Field | Before | After |
+| --- | --- | --- |
+| `main` | `dist/index.js` (ESM) | `dist/index.cjs` (CJS, for Node10 resolvers) |
+| `module` | absent | `dist/index.js` |
+| `exports["."]` | `types`, `import` | `types`, `import`, `require: ./dist/index.cjs` |
+| `exports["./manifest"]` | `types`, `import` | `types`, `import`, `require: ./dist/manifest.cjs` |
+| `tsup.format` | `["esm"]` | `["esm", "cjs"]` |
+
+`type: "module"` is kept, so `dist/*.js` stays ESM and tsup emits the CJS half as `dist/*.cjs`.
+`dist/types/**` declarations are unchanged and are shared by both conditions.
+
+### 2. `scripts/check-packed-packages.mjs`
+
+The existing check installed packed tarballs as *direct* dependencies only, so
+`@weaverse/hydrogen`'s transitive `@weaverse/schema` resolved to the published registry copy and
+hid the regression source. Four hardening changes:
+
+1. Write a `pnpm-workspace.yaml` with `overrides` for every packed `@weaverse/*` package in the
+   scratch consumer, so transitive resolution also hits the tarballs under test.
+2. Assert every published entrypoint (except `@weaverse/cli`, ESM-only executable, and
+   `@weaverse/biome`, JSON-only) declares a `require` condition.
+3. `assertCommonJsArtifact` parses each `require` target and rejects it if it contains ESM
+   `import` / `export` / `export =` statements — this blocks the "point `require` at the ESM file"
+   shortcut from ever landing.
+4. Add `manifest-runtime.cjs`, a CommonJS smoke test that `require`s both `@weaverse/schema` and
+   `@weaverse/schema/manifest` from the packed tarballs and asserts the deterministic manifest hash;
+   and add both specifiers to the existing `consumer.cts` NodeNext CJS typecheck.
+
+The pre-existing `runtime.cjs` check already covered the Hydrogen CJS transitive path once the
+overrides were in place — it was the check that went RED on `main`.
+
+## Touched files / packages
+
+- `packages/schema/package.json`
+- `scripts/check-packed-packages.mjs`
+- `.specs/2026-07-25--schema-cjs-exports/{README.md,plan.md}`
+
+No source files, templates, archived packages, dependency upgrades, or version bumps.
+
+## Verification
+
+| Command | Result |
+| --- | --- |
+| `pnpm run package:check` (on `main`) | RED — `ERR_PACKAGE_PATH_NOT_EXPORTED` from `runtime.cjs` |
+| `pnpm run package:check` (fix reverted, guards kept) | RED — `@weaverse/schema has no require condition` |
+| `pnpm run package:check` (`require` → ESM file) | RED — `points its require condition at the ES module` |
+| `pnpm run package:check` (fixed) | GREEN — `Verified 8 packed packages and 10 TypeScript entrypoints` |
+| `pnpm run test` | GREEN — 8 tasks, 322 tests |
+| `pnpm run typecheck` | GREEN |
+| `pnpm run biome` | GREEN |
+
+Plus an out-of-tree packed-tarball consumer proving `require('@weaverse/schema')`,
+`require('@weaverse/schema/manifest')`, and `require('@weaverse/hydrogen')` all resolve, and that
+ESM imports still work.
+
+## Residual risk
+
+Version bumps and publishing are deliberately out of scope. `@weaverse/schema` must be released
+(minor, since the package contract gains a condition) and `@weaverse/hydrogen` must be re-pinned to
+that version before consumers see the fix.

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -24,19 +24,34 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/types/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./server": {
-      "types": "./dist/types/server.d.ts",
-      "import": "./dist/server.js",
-      "require": "./dist/server.cjs"
+      "import": {
+        "types": "./dist/types/server.d.ts",
+        "default": "./dist/server.js"
+      },
+      "require": {
+        "types": "./dist/types/server.d.cts",
+        "default": "./dist/server.cjs"
+      }
     },
     "./react": {
-      "types": "./dist/types/react.d.ts",
-      "import": "./dist/react.js",
-      "require": "./dist/react.cjs"
+      "import": {
+        "types": "./dist/types/react.d.ts",
+        "default": "./dist/react.js"
+      },
+      "require": {
+        "types": "./dist/types/react.d.cts",
+        "default": "./dist/react.cjs"
+      }
     }
   },
   "engines": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -8,14 +8,24 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/types/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./manifest": {
-      "types": "./dist/types/manifest.d.ts",
-      "import": "./dist/manifest.js",
-      "require": "./dist/manifest.cjs"
+      "import": {
+        "types": "./dist/types/manifest.d.ts",
+        "default": "./dist/manifest.js"
+      },
+      "require": {
+        "types": "./dist/types/manifest.d.cts",
+        "default": "./dist/manifest.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -2,17 +2,20 @@
   "name": "@weaverse/schema",
   "version": "0.13.0",
   "description": "Schema definitions for Weaverse",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "types": "dist/types/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./manifest": {
       "types": "./dist/types/manifest.d.ts",
-      "import": "./dist/manifest.js"
+      "import": "./dist/manifest.js",
+      "require": "./dist/manifest.cjs"
     },
     "./package.json": "./package.json"
   },
@@ -41,7 +44,8 @@
       "src/manifest.ts"
     ],
     "format": [
-      "esm"
+      "esm",
+      "cjs"
     ],
     "dts": true,
     "sourcemap": true,

--- a/scripts/build-declarations.mjs
+++ b/scripts/build-declarations.mjs
@@ -12,10 +12,14 @@ import ts from 'typescript'
 
 const DECLARATION_SUFFIX = /\.d\.ts$/
 const BUNDLED_DECLARATION = /\.d\.(?:ts|mts|cts)(?:\.map)?$/
+const SOURCE_MAPPING_COMMENT = /\n?\/\/# sourceMappingURL=.*\n?$/
 let packageDir = process.cwd()
 let sourceDir = join(packageDir, 'src')
 let outputDir = join(packageDir, 'dist', 'types')
 let configPath = join(packageDir, 'tsconfig.json')
+let packageType = JSON.parse(
+  readFileSync(join(packageDir, 'package.json'), 'utf8')
+).type
 function walk(directory) {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     let path = join(directory, entry.name)
@@ -66,6 +70,78 @@ function copyAuthoredDeclarations() {
   }
 }
 
+function collectModuleSpecifiers(sourceFile) {
+  let specifiers = []
+
+  function visit(node) {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier)
+    }
+    if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteral(node.argument.literal)
+    ) {
+      specifiers.push(node.argument.literal)
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return specifiers
+}
+
+/**
+ * `type: "module"` packages need CommonJS declarations for their `require`
+ * conditions. Without them TypeScript reads the shared `.d.ts` as ESM and
+ * rejects CommonJS consumers with TS1479 under `module: node16`/`node18`.
+ * Relative specifiers are rewritten to `.cjs` so the CommonJS declaration graph
+ * stays internally consistent under `skipLibCheck: false`.
+ */
+function emitCommonJsDeclarations() {
+  if (packageType !== 'module') {
+    return
+  }
+
+  for (let declarationFile of walk(outputDir).filter((file) =>
+    DECLARATION_SUFFIX.test(file)
+  )) {
+    let source = readFileSync(declarationFile, 'utf8').replace(
+      SOURCE_MAPPING_COMMENT,
+      '\n'
+    )
+    let sourceFile = ts.createSourceFile(
+      declarationFile,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS
+    )
+    let edits = collectModuleSpecifiers(sourceFile)
+      .filter(
+        (specifier) =>
+          specifier.text.startsWith('.') && specifier.text.endsWith('.js')
+      )
+      .map((specifier) => ({
+        start: specifier.getStart(sourceFile) + 1,
+        end: specifier.getEnd() - 1,
+        text: `${specifier.text.slice(0, -'.js'.length)}.cjs`,
+      }))
+      .sort((left, right) => right.start - left.start)
+    let output = source
+
+    for (let edit of edits) {
+      output = output.slice(0, edit.start) + edit.text + output.slice(edit.end)
+    }
+
+    writeFileSync(declarationFile.replace(DECLARATION_SUFFIX, '.d.cts'), output)
+  }
+}
+
 let formatHost = {
   getCanonicalFileName: (file) => file,
   getCurrentDirectory: () => packageDir,
@@ -107,4 +183,5 @@ if (diagnostics.length > 0) {
 }
 
 copyAuthoredDeclarations()
+emitCommonJsDeclarations()
 removeBundledDeclarations()

--- a/scripts/check-packed-packages.mjs
+++ b/scripts/check-packed-packages.mjs
@@ -25,6 +25,9 @@ let PNPM = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const RUNTIME_JSON_BLOCK = /```json\n([\s\S]*?)\n```/
 // Next's browser entry imports next/navigation, which is resolved by its bundler.
 const NODE_ESM_EXCLUSIONS = new Set(['@weaverse/next'])
+// @weaverse/cli is an ESM-only executable and @weaverse/biome only ships JSON,
+// so neither participates in the dual ESM/CJS runtime contract.
+const CJS_CONTRACT_EXCLUSIONS = new Set(['@weaverse/cli', '@weaverse/biome'])
 let publishedPackages = getPublishedPackages(ROOT_DIR)
 let typeEntrypoints = publishedPackages.flatMap((publishedPackage) =>
   publishedPackage.entrypoints
@@ -77,6 +80,28 @@ function verifyIdentityMap(declarationFile, declarationMap, sourceFile) {
 
 function normalizeEntry(entryFile) {
   return entryFile.startsWith('./') ? entryFile.slice(2) : entryFile
+}
+
+function assertCommonJsArtifact(specifier, artifactFile) {
+  let sourceFile = ts.createSourceFile(
+    artifactFile,
+    readFileSync(artifactFile, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS
+  )
+  let esmStatement = sourceFile.statements.find(
+    (statement) =>
+      ts.isImportDeclaration(statement) ||
+      ts.isExportDeclaration(statement) ||
+      ts.isExportAssignment(statement)
+  )
+
+  if (esmStatement) {
+    throw new Error(
+      `${specifier} points its require condition at the ES module ${artifactFile}`
+    )
+  }
 }
 
 function hasInterfaceProperty(declarationFile, interfaceName, propertyName) {
@@ -155,6 +180,11 @@ try {
     packedDependencies[packageJson.name] = `file:${tarball}`
   }
 
+  // Transitive @weaverse/* dependencies must resolve to the packed tarballs too,
+  // otherwise the registry copies mask packaging regressions such as a missing
+  // `require` condition reached through the @weaverse/hydrogen CJS build.
+  let packedOverrides = { ...packedDependencies }
+
   let rootPackageJson = JSON.parse(
     readFileSync(join(ROOT_DIR, 'package.json'), 'utf8')
   )
@@ -175,6 +205,12 @@ try {
       null,
       2
     )}\n`
+  )
+  writeFileSync(
+    join(consumerDir, 'pnpm-workspace.yaml'),
+    `overrides:\n${Object.entries(packedOverrides)
+      .map(([name, specifier]) => `  '${name}': '${specifier}'`)
+      .join('\n')}\n`
   )
   run(
     PNPM,
@@ -210,6 +246,20 @@ try {
       if (!existsSync(join(packedFolder, normalizeEntry(entryFile)))) {
         throw new Error(
           `${packageJson.name} is missing packed entry ${entryFile}`
+        )
+      }
+    }
+
+    if (!CJS_CONTRACT_EXCLUSIONS.has(packageJson.name)) {
+      for (let entrypoint of publishedPackage.entrypoints) {
+        if (!entrypoint.require) {
+          throw new Error(
+            `${entrypoint.specifier} has no require condition, so CommonJS consumers fail with ERR_PACKAGE_PATH_NOT_EXPORTED`
+          )
+        }
+        assertCommonJsArtifact(
+          entrypoint.specifier,
+          join(packedFolder, normalizeEntry(entrypoint.require))
         )
       }
     }
@@ -422,6 +472,32 @@ if (
 `
   )
   run(process.execPath, ['manifest-runtime.mjs'], { cwd: consumerDir })
+  writeFileSync(
+    join(consumerDir, 'manifest-runtime.cjs'),
+    `let { createSchema } = require('@weaverse/schema')
+let { generateComponentManifest } = require('@weaverse/schema/manifest')
+
+let schema = createSchema({ type: 'hero', title: 'Hero' })
+
+async function main() {
+  let artifact = await generateComponentManifest([{ schema }], {
+    source: { name: 'packed-consumer', revision: 'abc123' },
+  })
+  if (
+    artifact.hash !==
+    'sha256:03c8db23865fd426237481016f5f7f24f6b6ead22a4420e8ba374a537400902b'
+  ) {
+    throw new Error(\`Unexpected component manifest hash: \${artifact.hash}\`)
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})
+`
+  )
+  run(process.execPath, ['manifest-runtime.cjs'], { cwd: consumerDir })
 
   writeFileSync(
     join(consumerDir, 'index.ts'),
@@ -490,6 +566,8 @@ import { WeaverseClient } from '@weaverse/hydrogen'
 import { createWeaverseNextClient } from '@weaverse/next'
 import { getWeaverseNextConfigs } from '@weaverse/next/server'
 import { WeaverseRoot } from '@weaverse/react'
+import { createSchema } from '@weaverse/schema'
+import { generateComponentManifest } from '@weaverse/schema/manifest'
 
 void [
   Weaverse,
@@ -500,6 +578,8 @@ void [
   createWeaverseNextClient,
   getWeaverseNextConfigs,
   WeaverseRoot,
+  createSchema,
+  generateComponentManifest,
 ]
 `
   )

--- a/scripts/check-packed-packages.mjs
+++ b/scripts/check-packed-packages.mjs
@@ -82,7 +82,59 @@ function normalizeEntry(entryFile) {
   return entryFile.startsWith('./') ? entryFile.slice(2) : entryFile
 }
 
-function assertCommonJsArtifact(specifier, artifactFile) {
+/**
+ * Internal @weaverse/* dependencies are always pinned to exact versions, so an
+ * exact match is the only range shape that has to be understood here. Anything
+ * else is treated as incompatible and left un-overridden rather than silently
+ * redirected to a version the declaring package never asked for.
+ */
+function acceptsPackedVersion(range, packedVersion) {
+  return range === packedVersion
+}
+
+/**
+ * Node decides a file's module format from its extension and the nearest
+ * package.json `type`, not from its syntax. Classify the same way so a `.js`
+ * require target inside a `type: "module"` package is rejected even when it
+ * happens to contain no import/export statement.
+ */
+function getNodeModuleFormat(artifactFile, packedPackageJson) {
+  if (artifactFile.endsWith('.cjs')) {
+    return 'commonjs'
+  }
+  if (artifactFile.endsWith('.mjs')) {
+    return 'module'
+  }
+  return packedPackageJson.type === 'module' ? 'module' : 'commonjs'
+}
+
+function hasEsmSyntax(sourceFile) {
+  return sourceFile.statements.some((statement) => {
+    if (
+      ts.isImportDeclaration(statement) ||
+      ts.isExportDeclaration(statement) ||
+      ts.isExportAssignment(statement)
+    ) {
+      return true
+    }
+    let modifiers = ts.canHaveModifiers(statement)
+      ? ts.getModifiers(statement)
+      : undefined
+    return Boolean(
+      modifiers?.some(
+        (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+      )
+    )
+  })
+}
+
+function assertCommonJsArtifact(specifier, artifactFile, packedPackageJson) {
+  if (getNodeModuleFormat(artifactFile, packedPackageJson) !== 'commonjs') {
+    throw new Error(
+      `${specifier} points its require condition at the ES module ${artifactFile}`
+    )
+  }
+
   let sourceFile = ts.createSourceFile(
     artifactFile,
     readFileSync(artifactFile, 'utf8'),
@@ -90,16 +142,10 @@ function assertCommonJsArtifact(specifier, artifactFile) {
     true,
     ts.ScriptKind.JS
   )
-  let esmStatement = sourceFile.statements.find(
-    (statement) =>
-      ts.isImportDeclaration(statement) ||
-      ts.isExportDeclaration(statement) ||
-      ts.isExportAssignment(statement)
-  )
 
-  if (esmStatement) {
+  if (hasEsmSyntax(sourceFile)) {
     throw new Error(
-      `${specifier} points its require condition at the ES module ${artifactFile}`
+      `${specifier} points its require condition at ${artifactFile}, which contains ES module syntax`
     )
   }
 }
@@ -183,7 +229,36 @@ try {
   // Transitive @weaverse/* dependencies must resolve to the packed tarballs too,
   // otherwise the registry copies mask packaging regressions such as a missing
   // `require` condition reached through the @weaverse/hydrogen CJS build.
-  let packedOverrides = { ...packedDependencies }
+  // Overriding a declared range would also hide incompatible internal pins, so
+  // only redirect edges whose declared range still accepts the packed version.
+  let packedVersions = new Map(
+    publishedPackages.map((publishedPackage) => [
+      publishedPackage.packageJson.name,
+      publishedPackage.packageJson.version,
+    ])
+  )
+  let packedOverrides = {}
+  let skippedOverrides = []
+
+  for (let publishedPackage of publishedPackages) {
+    for (let [dependency, range] of Object.entries(
+      publishedPackage.packageJson.dependencies ?? {}
+    )) {
+      let packedVersion = packedVersions.get(dependency)
+      if (!packedVersion) {
+        continue
+      }
+
+      let edge = `${publishedPackage.packageJson.name}>${dependency}`
+      if (acceptsPackedVersion(range, packedVersion)) {
+        packedOverrides[edge] = packedDependencies[dependency]
+      } else {
+        skippedOverrides.push(
+          `${edge}@${range} does not accept packed ${packedVersion}`
+        )
+      }
+    }
+  }
 
   let rootPackageJson = JSON.parse(
     readFileSync(join(ROOT_DIR, 'package.json'), 'utf8')
@@ -206,10 +281,15 @@ try {
       2
     )}\n`
   )
+  if (skippedOverrides.length > 0) {
+    console.log(
+      `Leaving registry resolution in place for incompatible internal pins:\n  ${skippedOverrides.join('\n  ')}`
+    )
+  }
   writeFileSync(
     join(consumerDir, 'pnpm-workspace.yaml'),
     `overrides:\n${Object.entries(packedOverrides)
-      .map(([name, specifier]) => `  '${name}': '${specifier}'`)
+      .map(([edge, specifier]) => `  '${edge}': '${specifier}'`)
       .join('\n')}\n`
   )
   run(
@@ -259,8 +339,35 @@ try {
         }
         assertCommonJsArtifact(
           entrypoint.specifier,
-          join(packedFolder, normalizeEntry(entrypoint.require))
+          join(packedFolder, normalizeEntry(entrypoint.require)),
+          packedPackageJson
         )
+
+        // A `type: "module"` package must ship CommonJS declarations for its
+        // require branch. Reusing the ESM `.d.ts` makes TypeScript reject
+        // CommonJS consumers with TS1479 under `module: node16`/`node18`.
+        if (
+          packedPackageJson.type === 'module' &&
+          entrypoint.requireTypes &&
+          !entrypoint.requireTypes.endsWith('.d.cts')
+        ) {
+          throw new Error(
+            `${entrypoint.specifier} resolves require-condition types to ${entrypoint.requireTypes}, which TypeScript reads as ESM`
+          )
+        }
+      }
+    }
+
+    for (let entrypoint of publishedPackage.entrypoints) {
+      for (let declaration of [entrypoint.types, entrypoint.requireTypes]) {
+        if (
+          declaration &&
+          !existsSync(join(packedFolder, normalizeEntry(declaration)))
+        ) {
+          throw new Error(
+            `${entrypoint.specifier} is missing packed declaration ${declaration}`
+          )
+        }
       }
     }
 
@@ -639,6 +746,62 @@ void legacyLooseSchema
       { cwd: consumerDir }
     )
   }
+
+  // `module: node16` is the stable CommonJS mode most consumers pin. Unlike
+  // NodeNext it refuses to require an ESM declaration file, so this is the mode
+  // that proves each require condition ships real CommonJS types. Only the
+  // dual-format Weaverse packages are covered here; third-party declarations
+  // are out of this contract's scope, so `skipLibCheck` stays on.
+  writeFileSync(
+    join(consumerDir, 'node16-consumer.cts'),
+    `import { Weaverse } from '@weaverse/core'
+import { assignVariant } from '@weaverse/experiments'
+import { createExposureTracker } from '@weaverse/experiments/react'
+import { getExperiments } from '@weaverse/experiments/server'
+import { WeaverseRoot } from '@weaverse/react'
+import { createSchema } from '@weaverse/schema'
+import { generateComponentManifest } from '@weaverse/schema/manifest'
+
+void [
+  Weaverse,
+  assignVariant,
+  createExposureTracker,
+  getExperiments,
+  WeaverseRoot,
+  createSchema,
+  generateComponentManifest,
+]
+`
+  )
+  let node16Config = join(consumerDir, 'tsconfig.node16.json')
+  writeFileSync(
+    node16Config,
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'node16',
+          moduleResolution: 'node16',
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+          jsx: 'react-jsx',
+        },
+        files: ['node16-consumer.cts'],
+      },
+      null,
+      2
+    )}\n`
+  )
+  run(
+    process.execPath,
+    [
+      join(ROOT_DIR, 'node_modules', 'typescript', 'bin', 'tsc'),
+      '--project',
+      node16Config,
+    ],
+    { cwd: consumerDir }
+  )
 
   writeFileSync(
     join(consumerDir, 'legacy-resolution.ts'),

--- a/scripts/public-packages.mjs
+++ b/scripts/public-packages.mjs
@@ -2,23 +2,27 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import ts from 'typescript'
 
-function findCondition(value, condition) {
+/**
+ * Resolve a conditional exports value the way Node and TypeScript do: walk keys
+ * in declaration order and follow the first key that is active or `default`.
+ * A naive search cannot be used here because `types` legally appears inside
+ * both the `import` and `require` branches with different targets.
+ */
+function findCondition(value, conditions) {
   if (typeof value === 'string') {
-    return condition === 'default' ? value : undefined
+    return value
   }
 
   if (!(value && typeof value === 'object')) {
     return
   }
 
-  if (typeof value[condition] === 'string') {
-    return value[condition]
-  }
-
-  for (let child of Object.values(value)) {
-    let match = findCondition(child, condition)
-    if (match) {
-      return match
+  for (let [key, child] of Object.entries(value)) {
+    if (key === 'default' || conditions.includes(key)) {
+      let match = findCondition(child, conditions)
+      if (match) {
+        return match
+      }
     }
   }
 
@@ -39,9 +43,10 @@ function getEntrypoints(packageJson) {
           subpath === '.'
             ? packageJson.name
             : `${packageJson.name}/${subpath.slice(2)}`,
-        types: findCondition(value, 'types'),
-        import: findCondition(value, 'import'),
-        require: findCondition(value, 'require'),
+        types: findCondition(value, ['types', 'import']),
+        requireTypes: findCondition(value, ['types', 'require']),
+        import: findCondition(value, ['import']),
+        require: findCondition(value, ['require']),
       }))
   }
 
@@ -50,6 +55,7 @@ function getEntrypoints(packageJson) {
       subpath: '.',
       specifier: packageJson.name,
       types: packageJson.types ?? packageJson.typings,
+      requireTypes: packageJson.types ?? packageJson.typings,
       import:
         packageJson.module ??
         (packageJson.type === 'module' ? packageJson.main : undefined),


### PR DESCRIPTION
Fixes #508

## Root cause

`@weaverse/schema@0.13.0` introduced an `exports` map that declared only the `import` condition:

```json
"exports": {
  ".":          { "types": "./dist/types/index.d.ts",    "import": "./dist/index.js" },
  "./manifest": { "types": "./dist/types/manifest.d.ts", "import": "./dist/manifest.js" }
}
```

Once an `exports` map exists, Node no longer falls back to `main`. Every `require()` of the package
root and of `./manifest` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`. `0.12.0` had no `exports` map,
so `require` fell back to `main` and Node's `require(ESM)` support handled it.

`@weaverse/hydrogen` still publishes a CJS bundle whose `dist/index.js` contains
`var schema$1 = require('@weaverse/schema')`, so every CommonJS consumer of Hydrogen broke
transitively.

## Design decision

The issue offers `"require": "./dist/index.js"` (pointing `require` at the ESM file) as one option.
Rejected: `@weaverse/hydrogen` declares `engines.node >= 20`, and unflagged synchronous `require(ESM)`
is not guaranteed across that matrix (Node 20.0–20.18 throws `ERR_REQUIRE_ESM`), plus it yields a
different namespace shape than a real CJS module. Every other dual package in this repo (`core`,
`react`, `hydrogen`, `next`, `experiments`) already ships a real CJS artifact — schema was the only
outlier. So schema now builds `esm` + `cjs` and declares both conditions.

## Changes

**`packages/schema/package.json`**

| Field | Before | After |
| --- | --- | --- |
| `main` | `dist/index.js` (ESM) | `dist/index.cjs` (CJS, for Node10 resolvers) |
| `module` | — | `dist/index.js` |
| `exports["."]` | `types`, `import` | + `require: ./dist/index.cjs` |
| `exports["./manifest"]` | `types`, `import` | + `require: ./dist/manifest.cjs` |
| `tsup.format` | `["esm"]` | `["esm", "cjs"]` |

`type: "module"` is kept, so `dist/*.js` stays ESM and tsup emits the CJS half as `dist/*.cjs`.
Declarations under `dist/types/**` are unchanged and shared by both conditions. No version bump, no
publish — release versioning is a separate gate.

**`scripts/check-packed-packages.mjs`** — the check installed packed tarballs only as *direct*
dependencies, so Hydrogen's transitive `@weaverse/schema` resolved to the registry copy and hid the
regression. Four hardening changes:

1. Write `pnpm-workspace.yaml` `overrides` for every packed `@weaverse/*` package in the scratch
   consumer, so transitive resolution also hits the tarballs under test.
2. Assert every published entrypoint declares a `require` condition (`@weaverse/cli` is an ESM-only
   executable and `@weaverse/biome` is JSON-only, both excluded).
3. `assertCommonJsArtifact` parses each `require` target and rejects it when it contains ESM
   `import` / `export` / `export =` statements, blocking the "point `require` at the ESM file"
   shortcut.
4. Add `manifest-runtime.cjs`, a CommonJS smoke test that `require`s both `@weaverse/schema` and
   `@weaverse/schema/manifest` from the packed tarballs and asserts the deterministic manifest hash;
   and add both specifiers to the existing `consumer.cts` NodeNext CJS typecheck.

**`.specs/2026-07-25--schema-cjs-exports/`** — spec folder per the repo's SDD rule.

## Test evidence

### RED — `pnpm run package:check` at base `1495c360`

```
Error: /Users/paul/.nvm/versions/node/v24.18.0/bin/node runtime.cjs failed
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in
  .../node_modules/.pnpm/@weaverse+hydrogen@.../node_modules/@weaverse/schema/package.json
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
exit 1
```

### RED — direct packed-tarball consumer at base

```
$ node -e "require('@weaverse/schema')"
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in .../@weaverse/schema/package.json

$ node -e "require('@weaverse/schema/manifest')"
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './manifest' is not defined by "exports" in .../@weaverse/schema/package.json

$ node -e "require('@weaverse/hydrogen')"
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in .../@weaverse/schema/package.json
```

### RED — new guards proven necessary

Reverting only the `package.json` fix while keeping the new checks:

```
Error: @weaverse/schema has no require condition, so CommonJS consumers fail with ERR_PACKAGE_PATH_NOT_EXPORTED
exit 1
```

Setting `"require": "./dist/index.js"` (the ESM file) instead of a real CJS artifact:

```
Error: @weaverse/schema points its require condition at the ES module .../@weaverse/schema/dist/index.js
exit 1
```

### GREEN

| Command | Exit | Output |
| --- | --- | --- |
| `pnpm run package:check` | 0 | `Verified 8 packed packages and 10 TypeScript entrypoints` |
| `pnpm run test` | 0 | 8 tasks successful — hydrogen 166, react 91 (+1 skipped), schema 65 |
| `pnpm run typecheck` | 0 | 6 tasks successful |
| `pnpm run biome` | 0 | `Checked 144 files. No fixes applied.` |
| `pnpm run build` | 0 | 6 tasks successful |

Out-of-tree packed-tarball consumer (all four `@weaverse/*` tarballs pinned via overrides):

```
$ node -e "require('@weaverse/schema'); require('@weaverse/schema/manifest'); require('@weaverse/hydrogen')"
schema require OK: function
manifest require OK: function
hydrogen CJS require OK: function
exit 0

$ node --input-type=module -e "import { createSchema } from '@weaverse/schema'; ..."
esm OK function function function
exit 0
```

`api-reports/` is unchanged — the public API surface is identical, only the resolution contract
changed.

## Residual risk

- Version bumps and publishing are out of scope. `@weaverse/schema` needs a release (minor — the
  package contract gains a condition) and `@weaverse/hydrogen` needs to be re-pinned to it before
  consumers see the fix.
- The packed-package consumer now uses pnpm `overrides`; if a future `@weaverse/*` package is added
  with an intentionally ESM-only contract it must be added to `CJS_CONTRACT_EXCLUSIONS` with a
  justification comment.
- Schema's CJS bundle roughly doubles the package's `dist` size. Runtime consumers are unaffected
  since bundlers pick the `import` condition.


---

## Review round 2 (autoreview: codex/gpt-5.6-sol)

Structured review of the first commit accepted 3 defects, all fixed in `f2e406a`:

**1. `require` branches resolved to ESM declarations (P1).** Both `require` conditions selected
`.cjs` implementations but still resolved `types` to the shared `.d.ts`. Because schema is
`type: "module"`, TypeScript reads those as ESM and rejects CommonJS consumers with **TS1479** under
`module: node16`/`node18`. The original `.cts` check passed only because NodeNext permits requiring
ESM. Reproduced directly:

```
$ tsc -p tsconfig.node16.json   # CJS consumer, before fix
probe.cts(1,30): error TS1479: The current file is a CommonJS module whose imports will produce
'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with
'require'. ... '@weaverse/schema'
probe.cts(2,43): error TS1479: ... '@weaverse/schema/manifest'
```

Fixed by emitting `.d.cts` declarations for `type: "module"` packages (relative `./x.js` specifiers
rewritten to `./x.cjs` so the CJS declaration graph is consistent under `skipLibCheck: false`) and
nesting `types` inside each of the `import` and `require` branches. `@weaverse/experiments` is the
only other `type: "module"` dual package and had the **identical latent defect** — same bug class,
same owner boundary — so it is fixed the same way.

**2. CJS artifact guard had false negatives (P2).** The guard only matched `ImportDeclaration` /
`ExportDeclaration` / `ExportAssignment`, so it missed `export const`, `export function`, and
`export class`; and it accepted a `.js` file in a `type: "module"` package that merely had no
import/export statement. Verified empirically:

```
MISSED   export const x = 1      MISSED   export function f(){}     MISSED   export class C{}
DETECTED export { a }            DETECTED import x from "y"
```

Now classifies module format the way Node does (extension + nearest `type`) *and* detects export
modifiers. Both halves proven RED independently.

**3. Blanket pnpm overrides masked stale internal pins (P2).** Bare-name overrides for every packed
package made pnpm ignore the ranges declared by packages under test — `@weaverse/next` pins
`@weaverse/schema@0.10.0` but was silently tested against packed `0.13.0`, removing pre-existing
install-time coverage. Overrides are now scoped to `parent>child` edges whose declared range accepts
the packed version; incompatible edges stay on registry resolution and are reported:

```
Leaving registry resolution in place for incompatible internal pins:
  @weaverse/next>@weaverse/react@5.16.4 does not accept packed 5.19.0
  @weaverse/next>@weaverse/schema@0.10.0 does not accept packed 0.13.0
```

Fixing those pins is release/version work and is out of this PR's scope.

**Consciously deferred — dual-package hazard on `schemaRegistry` (P2).** Building one entrypoint as
both ESM and CJS creates two `SchemaRegistry` classes and two `schemaRegistry` instances, so
`instanceof` and registry contents can diverge in a mixed-format process. Deferred as a follow-up,
not fixed here: it is inherent to *every* dual package in this repo (`core`, `react`, `hydrogen`,
`next`, `experiments` already ship both formats), no Weaverse package or template reads or mutates
`schemaRegistry`/`devTools` across a format boundary, and converging on one canonical instance
requires an ESM-wrapper-over-CJS build redesign — a different owner boundary than this fix.

### Supporting changes

`scripts/public-packages.mjs` — `findCondition` searched the whole exports tree for a condition name,
which breaks once `types` legally appears in both branches with different targets. It now resolves in
declaration order following only active or `default` keys, and exposes `requireTypes`.

`scripts/check-packed-packages.mjs` — additionally asserts `type: "module"` packages resolve
require-condition types to `.d.cts`, that every resolved declaration exists in the tarball, and adds
a `module: node16` CommonJS typecheck (the mode that actually catches TS1479).

### Round-2 evidence

| Command | Exit | Result |
| --- | --- | --- |
| `pnpm run package:check` | 0 | `Verified 8 packed packages and 10 TypeScript entrypoints` |
| `pnpm run test` | 0 | 8 tasks successful |
| `pnpm run typecheck` | 0 | 6 tasks successful |
| `pnpm run biome` | 0 | `Checked 144 files. No fixes applied.` |
| `pnpm run build` | 0 | 6 tasks successful |

New guards proven RED before the fix:

```
Error: @weaverse/schema resolves require-condition types to ./dist/types/index.d.ts, which TypeScript reads as ESM
Error: @weaverse/schema points its require condition at the ES module .../dist/index.js
```

Packed-tarball consumer, CJS typecheck across every CommonJS module mode:

```
node16    CJS-consumer errors=0
node18    CJS-consumer errors=0
nodenext  CJS-consumer errors=0
esm-consumer errors=0
```

Runtime (`require` and `import`) for schema, `schema/manifest`, hydrogen, and experiments: all pass.

Final autoreview on `f2e406a` is clean from two independent reviewers — codex/gpt-5.6-sol
("patch is correct", 0.94) and deepseek-v4-pro ("patch is correct", 0.95) — with no
accepted/actionable findings.
