### PR TITLE
fix(hydrogen): refresh settings on reused item stores

### DIFF
--- a/.specs/2026-07-26--507-hydrogen-set-data/README.md
+++ b/.specs/2026-07-26--507-hydrogen-set-data/README.md
@@ -1,0 +1,25 @@
+# Feature: Hydrogen item data refresh on reused item stores
+
+| Field            | Value                                                            |
+| ---------------- | ---------------------------------------------------------------- |
+| **Status**       | in-progress                                                      |
+| **Owner**        | @hta218                                                          |
+| **Issue**        | [#507](https://github.com/Weaverse/weaverse/issues/507)          |
+| **Branch**       | `fix/507-hydrogen-set-data`                                      |
+| **Created**      | 2026-07-26                                                       |
+| **Last Updated** | 2026-07-26                                                       |
+
+## Original Prompt
+
+> Fix @weaverse/hydrogen item-store updates so reused items flatten fresh serialized settings, reset omitted default-valued fields from the schema, and preserve settings for empty context-only setData({}) refreshes.
+
+## Summary
+
+`WeaverseHydrogenItem`'s constructor flattens serialized `item.data` (plus schema
+defaults) onto the top-level `_store`, but the inherited `WeaverseItemStore.setData`
+performs a raw shallow merge. On client-side navigations that reuse item stores
+(same item ids across locales), fresh settings land under `_store.data` while the
+stale flattened values keep rendering. This spec overrides `setData` in the
+Hydrogen item store so reused items flatten fresh settings, reset fields the
+payload omits because they equal a schema default, and still support the
+context-only `setData({})` refresh without wiping settings.

--- a/.specs/2026-07-26--507-hydrogen-set-data/README.md
+++ b/.specs/2026-07-26--507-hydrogen-set-data/README.md
@@ -2,7 +2,7 @@
 
 | Field            | Value                                                            |
 | ---------------- | ---------------------------------------------------------------- |
-| **Status**       | in-progress                                                      |
+| **Status**       | completed                                                        |
 | **Owner**        | @hta218                                                          |
 | **Issue**        | [#507](https://github.com/Weaverse/weaverse/issues/507)          |
 | **Branch**       | `fix/507-hydrogen-set-data`                                      |

--- a/.specs/2026-07-26--507-hydrogen-set-data/plan.md
+++ b/.specs/2026-07-26--507-hydrogen-set-data/plan.md
@@ -1,0 +1,77 @@
+# Plan — Hydrogen item data refresh on reused item stores
+
+## Problem
+
+`Weaverse.initProject()` (core) reuses item stores keyed by item id:
+
+```ts
+const itemInstance = itemInstances.get(item.id)
+if (itemInstance) itemInstance.setData(item)
+else this.createItemInstance(item)
+```
+
+Two asymmetries make reused stores render stale content:
+
+1. **Flattening asymmetry.** `WeaverseHydrogenItem`'s constructor does
+   `Object.assign(this._store, schemaData, data, rest)` — settings are flattened
+   to the top level. The inherited `setData` only does
+   `{ ...this._store, ...update }`, so the new settings sit unused under
+   `_store.data` while `_store.<field>` keeps the previous locale's value.
+2. **Omitted-default asymmetry.** Serialized payloads omit a field when its value
+   equals the schema default. DE → EN: DE sends `buttonText: 'In den Warenkorb'`,
+   EN omits `buttonText` (it equals the schema default `'Add to cart'`). A plain
+   flatten-merge leaves the German string in place; defaults must be re-applied
+   before the incoming nested data.
+
+Constraint: `syncReusedInstance` calls `setData({})` for context-only refreshes.
+That call must only swap the `_store` reference and notify — it must not reset
+settings to schema defaults.
+
+## Approach
+
+Override `setData` in `WeaverseHydrogenItem` (Hydrogen-owned, minimal):
+
+- Split `update` into `{ data, ...rest }` and resolve the schema from the
+  incoming `type` when present.
+- If `update` has no own keys → context-only refresh: re-create the `_store`
+  reference (`{ ...this._store }`), notify, return. No defaults, no resets.
+- Normalize updates that carry nested `data` or represent a complete serialized
+  item (`id` + `type`). Re-apply schema defaults before flattening incoming
+  settings; complete items still reset defaults when the optional `data`
+  property itself is absent.
+- Replace the stored nested `data` with the latest serialized value instead of
+  retaining the previous locale's payload. Schema-less and top-level-only
+  partial updates keep the base shallow-merge behavior.
+- Then `triggerUpdate()` and return `this.data`, matching the base contract.
+
+Scope is `@weaverse/hydrogen` only. `@weaverse/core` and `@weaverse/next` are
+untouched; a follow-up handles Next. No runtime-owner rebinding, no other
+lifecycle changes.
+
+## Tests (TDD, AAA, `should_*_when_*` naming)
+
+New file `packages/hydrogen/__tests__/weaverse-hydrogen-item.test.ts`, driving the
+real reused-item seam (`WeaverseHydrogen.setProjectData()` → core `initProject()`
+→ `itemInstance.setData(item)`):
+
+1. Explicit locale A → B values replace stale flattened settings.
+2. B → default locale resets a field omitted because it equals its schema default.
+3. A complete serialized item that omits optional `data` still resets defaults.
+4. The stored nested `data` reflects the latest serialized payload.
+5. Empty `setData({})` preserves settings, swaps the store reference, and notifies
+   subscribers.
+
+## Files touched
+
+- `packages/hydrogen/src/WeaverseHydrogenRoot.tsx` — add `setData` override to
+  `WeaverseHydrogenItem`.
+- `packages/hydrogen/__tests__/weaverse-hydrogen-item.test.ts` — new regression tests.
+- `api-reports/hydrogen.api.md` — public class gains a `setData` member (regenerated
+  via `pnpm run api:report` if it changes).
+- `.specs/2026-07-26--507-hydrogen-set-data/**` — this spec.
+
+## Verification
+
+- `pnpm exec vp test --run packages/hydrogen/__tests__/weaverse-hydrogen-item.test.ts`
+- `turbo test --filter=@weaverse/hydrogen`
+- `pnpm run typecheck`, `pnpm run biome`, `pnpm run package:check`

--- a/.specs/2026-07-26--507-hydrogen-set-data/work-logs.md
+++ b/.specs/2026-07-26--507-hydrogen-set-data/work-logs.md
@@ -1,0 +1,55 @@
+# Work Logs
+
+## 2026-07-26 — @hta218
+
+- Confirmed the seam: core `Weaverse.initProject()` reuses item stores by id and
+  calls `itemInstance.setData(item)`; `WeaverseItemStore.setData` shallow-merges
+  the raw item, so `WeaverseHydrogenItem`'s constructor-time flattening is never
+  repeated on reuse.
+- TDD RED: added `packages/hydrogen/__tests__/weaverse-hydrogen-item.test.ts`
+  driving `WeaverseHydrogen.setProjectData()` (real reuse path). 2 of 4 tests
+  failed as expected:
+  - `should_flatten_fresh_settings_...` → expected `'Add to bag'`, got
+    `'In den Warenkorb'`
+  - `should_reset_omitted_field_to_schema_default_...` → expected
+    `'Add to cart'`, got `'In den Warenkorb'`
+  The two `setData({})` tests passed from the start — they are regression guards
+  so the fix cannot break the context-only refresh.
+- GREEN: added a `setData` override on `WeaverseHydrogenItem`. It normalizes
+  complete serialized items and nested `data` updates, resolves defaults from
+  the incoming component type, keeps the nested serialized payload current, and
+  short-circuits an empty update to a bare `_store` reference swap plus
+  `triggerUpdate()`.
+- Independent review found missing coverage for full items without a `data`
+  property, stale nested `data`, and subscriber notification. The implementation
+  and regression suite were updated; the focused suite now has 7 passing tests.
+- Post-fix independent review returned `APPROVE` with no blocking or
+  non-blocking findings after rerunning the focused, package, typecheck, Biome,
+  and packed-package checks.
+- Scope held to `@weaverse/hydrogen`; `@weaverse/core` and `@weaverse/next`
+  untouched (Next handled in a follow-up).
+
+### Commands
+
+| Command | Result |
+| --- | --- |
+| `pnpm exec vp test --run packages/hydrogen/__tests__/weaverse-hydrogen-item.test.ts` | RED 2 failed / 2 passed → GREEN 7 passed after review hardening |
+| `pnpm exec turbo test --filter=@weaverse/hydrogen` | 13 files, 173 tests passed |
+| `pnpm run test` | 8 tasks successful |
+| `pnpm run typecheck` | 6 tasks successful |
+| `pnpm run biome` | 145 files checked, no errors |
+| `pnpm run package:check` | failed first (intentional API change), clean after report update |
+
+### API report
+
+`package:check` flagged one intentional public-API addition:
+
+```
+export class WeaverseHydrogenItem extends WeaverseItemStore {
++    setData: (update: Omit<ElementData, "id" | "type">) => ElementData;
+```
+
+The override makes `setData` an own member of the Hydrogen subclass (it was
+previously only inherited from `WeaverseItemStore`), so the signature now shows
+up in the report. Accepted via `pnpm run api:report`; `package:check` re-runs
+clean.

--- a/api-reports/hydrogen.api.md
+++ b/api-reports/hydrogen.api.md
@@ -617,6 +617,7 @@ export class WeaverseHydrogenItem extends WeaverseItemStore {
     constructor(initialData: HydrogenComponentData, weaverse: WeaverseHydrogen);
     get Element(): HydrogenElement;
     getSnapShot: () => ElementData;
+    setData: (update: Omit<ElementData, "id" | "type">) => ElementData;
     weaverse: WeaverseHydrogen;
 }
 

--- a/packages/hydrogen/__tests__/weaverse-hydrogen-item.test.ts
+++ b/packages/hydrogen/__tests__/weaverse-hydrogen-item.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  HydrogenComponentSchema,
+  HydrogenPageData,
+  WeaverseHydrogenParams,
+} from '../src/types'
+import {
+  registerComponent,
+  WeaverseHydrogen,
+} from '../src/WeaverseHydrogenRoot'
+
+const ITEM_ID = 'item-1'
+const ROOT_ID = 'root-1'
+
+const SCHEMA = {
+  type: 'test-add-to-cart',
+  title: 'Test Add To Cart',
+  settings: [
+    {
+      group: 'Content',
+      inputs: [
+        { type: 'text', name: 'buttonText', defaultValue: 'Add to cart' },
+        { type: 'text', name: 'heading', defaultValue: 'Featured product' },
+      ],
+    },
+  ],
+} as unknown as HydrogenComponentSchema
+
+// The page root item needs a registered schema too, otherwise its store logs
+// "Element is missing schema or not found!" and clutters the test output.
+const ROOT_SCHEMA = {
+  type: 'main',
+  title: 'Main',
+  settings: [],
+} as unknown as HydrogenComponentSchema
+
+function makePageData(itemData?: Record<string, unknown>): HydrogenPageData {
+  return {
+    id: 'page-1',
+    name: 'Page',
+    rootId: ROOT_ID,
+    items: [
+      { id: ROOT_ID, type: 'main', data: {}, childIds: [ITEM_ID] },
+      {
+        id: ITEM_ID,
+        type: SCHEMA.type,
+        ...(itemData === undefined ? {} : { data: itemData }),
+        parentId: ROOT_ID,
+      },
+    ],
+  } as unknown as HydrogenPageData
+}
+
+function makePageDataWithoutItemData(): HydrogenPageData {
+  return makePageData()
+}
+
+function makeInstance(itemData: Record<string, unknown>): WeaverseHydrogen {
+  return new WeaverseHydrogen({
+    data: makePageData(itemData),
+    internal: {},
+    pageId: 'page-1',
+    projectId: 'project-1',
+    requestInfo: { pathname: '/', search: '', queries: {} },
+    weaverseApiBase: 'https://api.weaverse.io',
+    weaverseApiKey: 'key',
+    weaverseHost: 'https://studio.weaverse.io',
+    weaverseVersion: '',
+  } as unknown as WeaverseHydrogenParams)
+}
+
+describe('WeaverseHydrogenItem.setData', () => {
+  beforeEach(() => {
+    // Item stores live in a static Map shared across instances — the reuse
+    // path under test depends on it, so reset it between tests.
+    WeaverseHydrogen.itemInstances.clear()
+    for (const schema of [SCHEMA, ROOT_SCHEMA]) {
+      registerComponent({
+        type: schema.type,
+        Component: (() => null) as never,
+        schema,
+      })
+    }
+  })
+
+  it('should_flatten_fresh_settings_when_reused_item_receives_new_locale_data', () => {
+    let weaverse = makeInstance({ buttonText: 'In den Warenkorb' })
+
+    weaverse.setProjectData(makePageData({ buttonText: 'Add to bag' }))
+
+    expect(weaverse.itemInstances.get(ITEM_ID)?.data.buttonText).toBe(
+      'Add to bag'
+    )
+  })
+
+  it('should_reset_omitted_field_to_schema_default_when_reused_item_omits_it', () => {
+    let weaverse = makeInstance({ buttonText: 'In den Warenkorb' })
+
+    // EN payload omits `buttonText` because it equals the schema default.
+    weaverse.setProjectData(makePageData({}))
+
+    expect(weaverse.itemInstances.get(ITEM_ID)?.data.buttonText).toBe(
+      'Add to cart'
+    )
+  })
+
+  it('should_reset_schema_defaults_when_serialized_item_omits_data_property', () => {
+    let weaverse = makeInstance({ buttonText: 'In den Warenkorb' })
+
+    weaverse.setProjectData(makePageDataWithoutItemData())
+
+    expect(weaverse.itemInstances.get(ITEM_ID)?.data.buttonText).toBe(
+      'Add to cart'
+    )
+  })
+
+  it('should_replace_nested_serialized_data_when_reused_item_receives_fresh_data', () => {
+    let weaverse = makeInstance({ buttonText: 'In den Warenkorb' })
+
+    weaverse.setProjectData(makePageData({ buttonText: 'Add to bag' }))
+
+    expect(weaverse.itemInstances.get(ITEM_ID)?.data.data).toEqual({
+      buttonText: 'Add to bag',
+    })
+  })
+
+  it('should_preserve_settings_when_setData_receives_empty_update', () => {
+    let weaverse = makeInstance({ buttonText: 'In den Warenkorb' })
+    let item = weaverse.itemInstances.get(ITEM_ID)
+
+    item?.setData({})
+
+    expect(item?.data.buttonText).toBe('In den Warenkorb')
+  })
+
+  it('should_swap_store_reference_when_setData_receives_empty_update', () => {
+    let weaverse = makeInstance({ buttonText: 'In den Warenkorb' })
+    let item = weaverse.itemInstances.get(ITEM_ID)
+    let before = item?.data
+
+    item?.setData({})
+
+    expect(item?.data).not.toBe(before)
+  })
+
+  it('should_notify_subscribers_when_setData_receives_empty_update', () => {
+    let weaverse = makeInstance({ buttonText: 'In den Warenkorb' })
+    let item = weaverse.itemInstances.get(ITEM_ID)
+    let listener = vi.fn()
+    item?.subscribe(listener)
+
+    item?.setData({})
+
+    expect(listener).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
+++ b/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
@@ -108,6 +108,54 @@ export class WeaverseHydrogenItem extends WeaverseItemStore {
   }
 
   /**
+   * Override setData to flatten serialized `data` the same way the constructor
+   * does. Core's `initProject()` reuses item stores keyed by item id (identical
+   * ids across locales), and the inherited setData only shallow-merges the raw
+   * item — fresh settings would land under `_store.data` while the stale
+   * flattened values keep rendering.
+   *
+   * Schema defaults are re-applied ahead of incoming settings because a
+   * serialized payload can omit fields — or the optional `data` object itself —
+   * when values equal schema defaults. The stored nested `data` is also replaced
+   * so the public serialized state does not retain the previous locale payload.
+   *
+   * An empty update is the context-only refresh from `syncReusedInstance`: swap
+   * the store reference so memoized subscribers re-render, and leave the
+   * settings untouched.
+   */
+  setData = (update: Omit<ElementData, 'id' | 'type'>) => {
+    let source = update ?? {}
+    let { data, ...rest } = source
+    let isEmptyUpdate = Object.keys(source).length === 0
+
+    if (isEmptyUpdate) {
+      this._store = { ...this._store }
+    } else {
+      let type = source.type ?? this._store.type
+      let schema = this.weaverse.elementRegistry.get(type)?.schema
+      let isSerializedItem = 'id' in source && 'type' in source
+      let shouldNormalize = data !== undefined || isSerializedItem
+
+      if (schema && shouldNormalize) {
+        let { data: _previousData, ...store } = this._store
+        let schemaData = generateDataFromSchema(schema)
+        this._store = {
+          ...store,
+          ...(data === undefined ? {} : { data }),
+          ...schemaData,
+          ...data,
+          ...rest,
+        }
+      } else {
+        this._store = { ...this._store, ...source }
+      }
+    }
+
+    this.triggerUpdate()
+    return this.data
+  }
+
+  /**
    * Override getSnapShot to merge translation data when in translation mode.
    * Memoizes the result: returns the same object reference as long as
    * both `_store` and the translation entry haven't changed.


### PR DESCRIPTION
Fixes #507

Restore fresh Hydrogen component settings when client navigation reuses item IDs.

- Reapply schema defaults before flattening incoming serialized settings.
- Preserve `setData({})` as a context-only store refresh without resetting settings.
- Add regression coverage for explicit locale values, omitted default-valued fields, and context-only refreshes.

`@weaverse/next` remains intentionally scoped to a separate follow-up.

Verification:
- `pnpm run test`
- `pnpm run typecheck`
- `pnpm run biome`
- `pnpm run package:check`
