### PR TITLE
v2026.9.7 - Shopify Markets localization and dependency refresh

### DIFF
--- a/.weaverse/component-manifest.json
+++ b/.weaverse/component-manifest.json
@@ -2,8 +2,8 @@
   "version": 1,
   "source": {
     "name": "@weaverse/pilot",
-    "revision": "v2026.8.17",
-    "version": "2026.8.17"
+    "revision": "v2026.9.7",
+    "version": "2026.9.7"
   },
   "components": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weaverse/pilot",
-  "version": "2026.8.17",
+  "version": "2026.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weaverse/pilot",
-      "version": "2026.8.17",
+      "version": "2026.9.7",
       "license": "MIT",
       "dependencies": {
         "@fontsource-variable/cabin": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weaverse/pilot",
-  "version": "2026.8.17",
+  "version": "2026.9.7",
   "description": "A production-ready Shopify storefront built with Hydrogen and Weaverse",
   "keywords": [
     "shopify",


### PR DESCRIPTION
## What's in this release

Version bump to `2026.9.7`. The bulk of this release is the Shopify Markets localization work tracked in Weaverse/pilot#168, plus a maintenance pass over the test suite and dependencies.

### New features

- Migrate to the Weaverse Translation Manager and add support for 8 new languages
- Configure Cloudflare Workers deployment and environment settings

### Bug fixes

All under Weaverse/pilot#168 — localization defects the live storefront exposed:

- Give anonymous carts the market they were created on
- Keep sign-in and sign-out on the shopper's market, and refuse invented market prefixes
- Keep Shopify URL redirects on the shopper's market
- Send every public redirect through one same-origin rule
- Keep the market on internal API requests, covering every featured-products path
- Stop the page and article routes sending the public locale
- Stop section loaders sending the public locale to Shopify
- Give Weaverse the public locale and the Our Team query a market to ask for
- Restore every market URL and honour cleared merchant copy
- Stop shipping English translations twice
- Fix stale Weaverse content on locale switch and remove the duplicate language switcher

### Improvements

- Drive localization from one canonical market table
- Align locale path prefixes with language codes
- Migrate the remaining UI strings to the translation manager
- Consolidate the test suite into a single unit runner (#478)
- Pin the patchable dev-scope dependencies past their advisories (#479)
- Refresh dependencies: range-permitted and exact-pinned minors (#480)

### Other

- Require portable requirements in the SDD convention (#476)
- Add the September 2026 dependency refresh spec

## Verification

- `npm run biome` — clean
- `npm run typecheck` — clean
- `npm test` — 193 passed
- `npm run build` — clean
- `npm run weaverse:manifest:check` — up to date, 82 components
- `npm run weaverse:audit` — 82 components, 489 settings

## Known state

Five Dependabot alerts remain open, all `react-router` runtime advisories. Their minimum fix is `7.18.3`, and `@shopify/hydrogen@2026.4.5` declares peer `react-router: ~7.16.0` — still the latest stable Hydrogen. TypeScript 7 and GraphQL 17 are blocked for the same class of reason and are deferred to their own work.